### PR TITLE
Enhance migration reliability, introduce `--no-containers` & reset tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ arc_pinned_tabs_export.json
 test_export.json
 *.log
 *.backup.*
+backups/
 
 # Migration script generated files
 workspace_uuid_mapping.json

--- a/migrate_arc_to_zen.py
+++ b/migrate_arc_to_zen.py
@@ -116,14 +116,25 @@ class Arc2ZenMigrator:
 
         return running_browsers, len(running_browsers) > 0
 
-    def run_migration(self, dry_run: bool = False, zen_profile_name: Optional[str] = None, arc_space_name: Optional[str] = None, import_open_tabs: bool = False) -> bool:
+    def run_migration(
+        self,
+        dry_run: bool = False,
+        zen_profile_name: Optional[str] = None,
+        arc_space_name: Optional[str] = None,
+        import_open_tabs: bool = False,
+        no_containers: bool = False,
+    ) -> bool:
         """Run the complete Arc to Zen migration process."""
 
         print("🔄 Arc to Zen Browser Migration v1.2 (2025-09-29)")
         print("=" * 50)
 
         logger.info("Starting Arc to Zen migration")
-        logger.info(f"Options: dry_run={dry_run}, zen_profile={zen_profile_name}, arc_space={arc_space_name}, import_open_tabs={import_open_tabs}")
+        logger.info(
+            f"Options: dry_run={dry_run}, zen_profile={zen_profile_name}, "
+            f"arc_space={arc_space_name}, import_open_tabs={import_open_tabs}, "
+            f"no_containers={no_containers}"
+        )
 
         # Clean up any previous export file to prevent caching issues
         if self.temp_export_file.exists():
@@ -246,26 +257,36 @@ class Arc2ZenMigrator:
         zen_space_importer = ZenSpaceImporter(zen_profile)
 
         # Import spaces and get container mappings
-        container_mappings = zen_space_importer.import_arc_spaces_as_containers(arc_export_data, dry_run=dry_run)
-
-        # In dry run, container_mappings will be empty, but that's expected
-        if dry_run:
+        if no_containers:
+            print("  🚫 No container assignment (regular browsing context)")
+            # Use container ID 0 (no container) for all spaces
+            container_mappings = {}
+            for space in arc_export_data.get('spaces', []):
+                space_name = space['space_name']
+                container_mappings[space_name] = 0  # No container
             space_success = True
-            # Create mock container mappings for dry run
-            container_mappings = {}
-            for space in arc_export_data.get('spaces', []):
-                space_name = space['space_name']
-                container_mappings[space_name] = 1  # Default container
         else:
-            space_success = container_mappings is not None and len(container_mappings) > 0
+            print("  🔒 Creating separate containers for each Arc space (cookie isolation)")
+            container_mappings = zen_space_importer.import_arc_spaces_as_containers(arc_export_data, dry_run=dry_run)
 
-        if not space_success:
-            print("⚠️ Failed to create Zen workspaces, but continuing with import...")
-            # Use default container mappings as fallback
-            container_mappings = {}
-            for space in arc_export_data.get('spaces', []):
-                space_name = space['space_name']
-                container_mappings[space_name] = 1  # Default container
+            # In dry run, container_mappings will be empty, but that's expected
+            if dry_run:
+                space_success = True
+                # Create mock container mappings for dry run
+                container_mappings = {}
+                for space in arc_export_data.get('spaces', []):
+                    space_name = space['space_name']
+                    container_mappings[space_name] = 1  # Default container
+            else:
+                space_success = container_mappings is not None and len(container_mappings) > 0
+
+            if not space_success:
+                print("⚠️ Failed to create Zen workspaces, but continuing with import...")
+                # Use default container mappings as fallback
+                container_mappings = {}
+                for space in arc_export_data.get('spaces', []):
+                    space_name = space['space_name']
+                    container_mappings[space_name] = 1  # Default container
 
         # Detect Zen storage format: modern (zen-sessions.jsonlz4) vs legacy (SQLite tables)
         uses_sessions = (selected_zen_profile / "zen-sessions.jsonlz4").exists()
@@ -410,6 +431,12 @@ Examples:
         help='Enable verbose logging output'
     )
 
+    parser.add_argument(
+        '--no-containers',
+        action='store_true',
+        help='Do not assign any container to tabs (container ID 0 - regular browsing). By default, separate containers are created for each Arc space. You can manually assign containers later in Zen.'
+    )
+
     args = parser.parse_args()
 
     if args.verbose:
@@ -423,7 +450,8 @@ Examples:
             dry_run=args.dry_run,
             zen_profile_name=args.zen_profile,
             arc_space_name=args.arc_space,
-            import_open_tabs=args.open_tabs
+            import_open_tabs=args.open_tabs,
+            no_containers=args.no_containers,
         )
 
         if success and not args.dry_run:

--- a/reset_zen.py
+++ b/reset_zen.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Zen Profile Reset Tool
+
+COMPLETELY resets a Zen profile to fresh state for migration testing.
+This is more destructive than cleanup - it removes ALL custom data.
+"""
+
+import argparse
+import sqlite3
+import json
+import sys
+import shutil
+from pathlib import Path
+import logging
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Import our modules
+sys.path.append(str(Path(__file__).parent / "src"))
+from zen_schema_analyzer import ZenSchemaAnalyzer
+
+class ZenResetter:
+    """Completely reset Zen profile to fresh state."""
+
+    def __init__(self):
+        self.home_dir = Path.home()
+
+    def reset_zen_profile(self, zen_profile, dry_run: bool = False) -> bool:
+        """Completely reset a Zen profile."""
+
+        print("🔄 Zen Profile Complete Reset Tool")
+        print("=" * 50)
+        print(f"Profile: {zen_profile.name}")
+        print()
+
+        if dry_run:
+            print("🧪 DRY RUN MODE - Showing what would be reset\n")
+        else:
+            print("⚠️  WARNING: This will COMPLETELY RESET the Zen profile!")
+            print("⚠️  ALL custom data will be removed:")
+            print("   • All pinned tabs")
+            print("   • All workspaces (except Default)")
+            print("   • All containers/spaces")
+            print("   • All bookmarks")
+            print("   • All browsing history")
+            print("   • All preferences")
+            print()
+            response = input("Are you ABSOLUTELY sure? Type 'RESET' to continue: ")
+            if response != 'RESET':
+                print("❌ Reset cancelled")
+                return False
+            print()
+
+        # zen_profile is already a Path object
+        profile_path = zen_profile if isinstance(zen_profile, Path) else zen_profile.path
+        db_path = profile_path / "places.sqlite"
+
+        if not db_path.exists():
+            print(f"❌ Database not found: {db_path}")
+            return False
+
+        # Test database lock
+        try:
+            test_conn = sqlite3.connect(db_path, timeout=1.0)
+            test_conn.execute("SELECT 1")
+            test_conn.close()
+        except sqlite3.OperationalError as e:
+            print(f"❌ Database is locked: {e}")
+            print("💡 Make sure Zen browser is completely closed")
+            return False
+
+        if dry_run:
+            print("📊 Files that would be reset:")
+            print(f"  • {db_path.name} (main database)")
+            print(f"  • containers.json (workspaces/containers)")
+            print(f"  • prefs.js (preferences)")
+            print(f"  • .parentlock (if exists)")
+            print()
+            print("🧪 Dry run complete. Run without --dry-run to perform reset.")
+            return True
+
+        # Create comprehensive backup
+        backups_dir = Path.cwd() / "backups"
+        backups_dir.mkdir(exist_ok=True)
+        backup_dir = backups_dir / f"zen_profile_backup_{int(db_path.stat().st_mtime)}"
+        try:
+            backup_dir.mkdir(exist_ok=True, parents=True)
+            shutil.copy2(db_path, backup_dir / "places.sqlite")
+
+            containers_file = profile_path / "containers.json"
+            if containers_file.exists():
+                shutil.copy2(containers_file, backup_dir / "containers.json")
+
+            prefs_file = profile_path / "prefs.js"
+            if prefs_file.exists():
+                shutil.copy2(prefs_file, backup_dir / "prefs.js")
+
+            print(f"💾 Created backup: backups/{backup_dir.name}\n")
+        except Exception as e:
+            print(f"⚠️  Failed to create backup: {e}")
+            print("Continuing anyway...\n")
+
+        print("🧹 Resetting profile...\n")
+
+        try:
+            # Reset database
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
+
+            # Remove all pinned tabs
+            cursor.execute("DELETE FROM zen_pins")
+            pins_removed = cursor.rowcount
+            print(f"  ✅ Removed {pins_removed} pinned tabs")
+
+            # Remove all workspaces except Default
+            cursor.execute("DELETE FROM zen_workspaces WHERE name != 'Default'")
+            workspaces_removed = cursor.rowcount
+            print(f"  ✅ Removed {workspaces_removed} workspaces")
+
+            # Remove ALL bookmarks (complete reset)
+            cursor.execute("DELETE FROM moz_bookmarks WHERE id > 5")  # Keep root folders only
+            bookmarks_removed = cursor.rowcount
+            print(f"  ✅ Removed {bookmarks_removed} bookmarks")
+
+            # Clear history
+            cursor.execute("DELETE FROM moz_historyvisits")
+            cursor.execute("DELETE FROM moz_places WHERE visit_count = 0")
+            print(f"  ✅ Cleared browsing history")
+
+            # Vacuum to reclaim space
+            conn.commit()
+            print(f"  🗜️  Optimizing database...")
+            cursor.execute("VACUUM")
+
+            conn.close()
+
+            # Reset containers.json to default
+            containers_file = profile_path / "containers.json"
+            if containers_file.exists():
+                default_containers = {
+                    "version": 5,
+                    "identities": [
+                        {
+                            "userContextId": 1,
+                            "public": True,
+                            "icon": "fingerprint",
+                            "color": "blue",
+                            "name": "Personal"
+                        }
+                    ]
+                }
+                with open(containers_file, 'w') as f:
+                    json.dump(default_containers, f, indent=2)
+                print(f"  ✅ Reset containers.json to default")
+
+            # Remove lock file if exists
+            parentlock = profile_path / ".parentlock"
+            if parentlock.exists():
+                parentlock.unlink()
+                print(f"  ✅ Removed .parentlock file")
+
+            # Remove WAL files if they exist
+            wal_files = list(profile_path.glob("*.sqlite-wal")) + list(profile_path.glob("*.sqlite-shm"))
+            for wal_file in wal_files:
+                wal_file.unlink()
+                print(f"  ✅ Removed {wal_file.name}")
+
+            print()
+            print("✅ Profile reset completed successfully!")
+            print("💡 The profile is now in a fresh state")
+            print("💡 You can now run the migration again")
+            return True
+
+        except Exception as e:
+            print(f"\n❌ Reset failed: {e}")
+            logger.exception("Reset error")
+            return False
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Completely reset Zen profile to fresh state",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+⚠️  WARNING: This is DESTRUCTIVE and removes ALL custom data!
+
+Use this when:
+  • Testing migrations repeatedly
+  • Zen profile is corrupted
+  • You want a completely fresh start
+
+Examples:
+  python3 reset_zen.py                    # Interactive reset
+  python3 reset_zen.py --dry-run          # Preview what would be reset
+  python3 reset_zen.py --zen-profile Default  # Reset specific profile
+        """
+    )
+
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview reset without making changes'
+    )
+
+    parser.add_argument(
+        '--zen-profile',
+        type=str,
+        help='Name or partial name of Zen profile to reset'
+    )
+
+    args = parser.parse_args()
+
+    # Find Zen profile
+    print("\n🔍 Locating Zen browser...")
+    zen_analyzer = ZenSchemaAnalyzer()
+    zen_profiles = zen_analyzer.find_zen_profiles()
+
+    if not zen_profiles:
+        print("❌ No Zen profiles found! Make sure Zen browser is installed.")
+        sys.exit(1)
+
+    # Select Zen profile
+    selected_zen_profile = None
+    if args.zen_profile:
+        for profile in zen_profiles:
+            if args.zen_profile in profile.name:
+                selected_zen_profile = profile
+                break
+        if not selected_zen_profile:
+            print(f"❌ Zen profile '{args.zen_profile}' not found!")
+            sys.exit(1)
+    else:
+        # Use first available profile
+        selected_zen_profile = zen_profiles[0]
+
+    print(f"✅ Using Zen profile: {selected_zen_profile.name}\n")
+
+    # Create resetter and run
+    resetter = ZenResetter()
+    try:
+        success = resetter.reset_zen_profile(selected_zen_profile, dry_run=args.dry_run)
+        sys.exit(0 if success else 1)
+
+    except KeyboardInterrupt:
+        print("\n\n⚠️ Reset cancelled by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}")
+        logger.exception("Unexpected error during reset")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arc_pinned_tab_extractor.py
+++ b/src/arc_pinned_tab_extractor.py
@@ -96,7 +96,16 @@ class ArcPinnedTabExtractor:
                 sidebar_data = json.load(f)
 
             logger.info("✅ Loaded Arc StorableSidebar.json")
-            return self._parse_local_sidebar_data(sidebar_data)
+
+            # Try local sidebar first (fast path for most users)
+            arc_spaces = self._parse_local_sidebar_data(sidebar_data)
+
+            # If local sidebar is empty/incomplete, fall back to sync data
+            if not arc_spaces:
+                logger.info("⚠️  Local sidebar empty, trying sync data fallback...")
+                arc_spaces = self._parse_sidebar_data(sidebar_data)
+
+            return arc_spaces
 
         except Exception as e:
             logger.error(f"Failed to parse StorableSidebar.json: {e}")
@@ -177,9 +186,25 @@ class ArcPinnedTabExtractor:
                     item_id = items[i]
                     item_data = items[i + 1]
                     items_lookup[item_id] = item_data
+
+                    # Debug: Show what type of item this is
+                    if logger.level <= logging.DEBUG:
+                        data_section = item_data.get('data', {})
+                        if 'tab' in data_section:
+                            logger.debug(f"  🔍 Found tab item: {item_id[:20]}... - {item_data.get('title', 'Untitled')}")
+                        elif 'list' in data_section:
+                            logger.debug(f"  🔍 Found folder item: {item_id[:20]}... - {item_data.get('title', 'Untitled')}")
+                        elif 'itemContainer' in data_section:
+                            container_type = data_section['itemContainer'].get('containerType', {})
+                            logger.debug(f"  🔍 Found container item: {item_id[:20]}... - Type: {list(container_type.keys())}")
+                        else:
+                            logger.debug(f"  🔍 Found unknown item type: {item_id[:20]}... - Keys: {list(data_section.keys())}")
+
                     i += 2
                 else:
                     i += 1
+
+            logger.debug(f"Built items_lookup with {len(items_lookup)} items")
 
             # Process items in original order to preserve sidebar ordering
             pinned_tabs_by_space = {space_id: [] for space_id in spaces_info.keys()}
@@ -252,6 +277,7 @@ class ArcPinnedTabExtractor:
             # Use the sidebar spaces array to preserve Arc's space ordering
             if len(containers) > 1 and 'spaces' in containers[1]:
                 sidebar_spaces = containers[1]['spaces']
+                logger.debug(f"Processing {len(sidebar_spaces) // 2} spaces from sidebar")
                 for i in range(0, len(sidebar_spaces), 2):
                     if i + 1 < len(sidebar_spaces):
                         space_id = sidebar_spaces[i]
@@ -259,8 +285,11 @@ class ArcPinnedTabExtractor:
                         space_name = space_info['name']
                         space_icon = space_info['icon']
 
+                        logger.debug(f"  🔍 Processing space: {space_name} ({space_id})")
+
                         # Get the correct visual order using container childrenIds
                         display_order = self._get_space_display_order(space_id, items_lookup, data)
+                        logger.debug(f"    Display order has {len(display_order)} items")
 
 
                         if display_order:
@@ -619,8 +648,11 @@ class ArcPinnedTabExtractor:
                 if i + 1 < len(spaces) and isinstance(spaces[i], str):
                     if spaces[i] == space_id:
                         space_data = spaces[i + 1]
-                        return space_data.get('containerIDs', [])
+                        container_ids = space_data.get('containerIDs', [])
+                        logger.debug(f"      🔍 Space container IDs: {container_ids}")
+                        return container_ids
 
+        logger.debug(f"      ⚠️  No container IDs found for space {space_id}")
         return []
 
     def _is_pinned_content(self, item_id: str, items_lookup: Dict, data: Dict) -> bool:
@@ -688,6 +720,7 @@ class ArcPinnedTabExtractor:
         """
         space_container_ids = self._get_space_container_ids(space_id, data)
         if not space_container_ids:
+            logger.debug(f"      ⚠️  No container IDs, returning empty display order")
             return []
 
         containers = data.get('sidebar', {}).get('containers', [])
@@ -727,7 +760,7 @@ class ArcPinnedTabExtractor:
 
     def _get_unpinned_tab_order(self, space_id: str, items_lookup: Dict, data: Dict) -> List[str]:
         """Get the display order of unpinned (open) tabs in a space.
-        
+
         Finds the container UUID immediately following the 'unpinned' marker.
         """
         space_container_ids = self._get_space_container_ids(space_id, data)
@@ -754,6 +787,8 @@ class ArcPinnedTabExtractor:
                         if children_ids:
                             return children_ids
                         break
+        else:
+            logger.debug("      ⚠️  No items found in containers, returning empty")
 
         return []
 
@@ -777,7 +812,7 @@ class ArcPinnedTabExtractor:
         return self._get_folder_path_local(parent_data.get('parentID'), items_lookup, space_id, data)
 
     def _parse_sidebar_data(self, data: Dict) -> List[ArcSpace]:
-        """Parse the complete sidebar data structure."""
+        """Parse the complete sidebar data structure from sync data."""
         arc_spaces = []
 
         # Get space models from sync data
@@ -792,12 +827,39 @@ class ArcPinnedTabExtractor:
                     space_data = space_models[i + 1].get('value', {})
                     space_name = space_data.get('title', f'Space {space_id}')
 
+                    # Extract icon and color
+                    icon = None
+                    color = None
+                    custom_info = space_data.get('customInfo', {})
+
+                    # Extract icon
+                    icon_type = custom_info.get('iconType', {})
+                    if 'emoji_v2' in icon_type:
+                        icon = icon_type['emoji_v2']
+                        logger.info(f"  🎨 Found icon for {space_name}: {icon}")
+
+                    # Extract color
+                    window_theme = custom_info.get('windowTheme', {})
+                    if window_theme:
+                        primary_palette = window_theme.get('primaryColorPalette', {})
+                        if primary_palette:
+                            mid_tone = primary_palette.get('midTone', {})
+                            if mid_tone and 'red' in mid_tone and 'green' in mid_tone and 'blue' in mid_tone:
+                                r = max(0, min(1, mid_tone['red']))
+                                g = max(0, min(1, mid_tone['green']))
+                                b = max(0, min(1, mid_tone['blue']))
+                                color = {'r': r, 'g': g, 'b': b}
+                                logger.info(f"  🎨 Found color for {space_name}: RGB({r:.3f}, {g:.3f}, {b:.3f})")
+
                     logger.info(f"📍 Processing space: {space_name}")
 
                     # Find pinned container for this space
                     pinned_container_id = self._find_pinned_container(data, space_id)
                     if pinned_container_id:
                         arc_space = self._extract_space_content(data, space_id, space_name, pinned_container_id)
+                        # Update icon and color on the extracted space
+                        arc_space.icon = icon
+                        arc_space.color = color
                         if arc_space.pinned_tabs:
                             arc_spaces.append(arc_space)
                 i += 2
@@ -853,6 +915,9 @@ class ArcPinnedTabExtractor:
             else:
                 i += 1
 
+        # Track index for ordering
+        index_counter = 0
+
         # Find all items that belong to the pinned container
         for item_id, item_data in items_lookup.items():
             parent_id = item_data.get('parentID')
@@ -877,9 +942,11 @@ class ArcPinnedTabExtractor:
                             space_name=space_name,
                             folder_path=folder_path,
                             tab_id=item_id,
-                            parent_id=parent_id
+                            parent_id=parent_id,
+                            index=index_counter
                         )
                         pinned_tabs.append(pinned_tab)
+                        index_counter += 1
 
                 elif 'list' in data_section:
                     # This is a folder
@@ -888,9 +955,11 @@ class ArcPinnedTabExtractor:
                         title=item_data.get('title', 'Untitled Folder'),
                         parent_id=parent_id,
                         space_id=space_id,
-                        children_ids=item_data.get('childrenIds', [])
+                        children_ids=item_data.get('childrenIds', []),
+                        index=index_counter
                     )
                     folders.append(folder)
+                    index_counter += 1
 
         logger.info(f"  ✅ {space_name}: {len(pinned_tabs)} pinned tabs, {len(folders)} folders")
         return ArcSpace(space_id, space_name, pinned_tabs, folders, None, None)


### PR DESCRIPTION
A bunch of updates when I tried to use this to get it working. Unabashedly AI-generated with Claude.

For anyone that this isn't working for, maybe it will help them too! (e.g. #8 or #9)

---

## Add `--no-containers` flag to migrate without using container tabs

For my use case, I just wanted everything in the default profile without logical  seperation.

## Add tool to reset Zen profile

As I was debugging my own (partial) migrations, this was useful

## Improve detection of Zen-side migration blockers

This failure would come later, with a partial migration. Make it happen earlier.

## Make pinned tab extraction more robust using sync data

I'm not sure why `_parse_sidebar_data` was never called - this was important to actually extract the data in my case.

No idea if the "fallback" approach makes sense, but leaving it since it's maybe working for some people?