### PR TITLE
Add favicons, history, cookies, GUI app, and Windows + macOS DMG/ZIP release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag for the release artifact (e.g. 1.0.0)"
+        required: true
+        default: "0.0.0"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: macos-14            # arm64 runner
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: ver
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$DISPATCH_VERSION"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          # Reject anything that isn't dotted-numeric-with-optional-suffix.
+          if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+)*([.-][A-Za-z0-9]+)*$ ]]; then
+            echo "::error::Refusing version '$VERSION' (must be like 1.2.3 or 1.2.3-rc1)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-build.txt
+
+      - name: Render app icon
+        run: bash build/make_iconset.sh
+
+      - name: Build .app
+        run: bash build/make_app.sh
+
+      - name: Smoke-test the bundle
+        # Launch the app, give WKWebView ~5 seconds to render, then quit.
+        # If the .app crashes on launch (e.g. WebKit framework missing) the
+        # process exits before our timer fires and the build fails.
+        run: |
+          set -e
+          dist/Arc2Zen.app/Contents/MacOS/Arc2Zen &
+          PID=$!
+          sleep 5
+          if ! kill -0 $PID 2>/dev/null; then
+            echo "::error::Bundle exited prematurely on launch"
+            exit 1
+          fi
+          osascript -e 'tell application "Arc2Zen" to quit' || kill $PID
+          wait $PID 2>/dev/null || true
+
+      - name: Build .dmg
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: bash build/make_dmg.sh
+
+      - name: Upload DMG artifact (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Arc2Zen-${{ steps.ver.outputs.version }}-arm64
+          path: dist/Arc2Zen-*.dmg
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Arc2Zen ${{ steps.ver.outputs.version }}
+          body: |
+            Arc2Zen ${{ steps.ver.outputs.version }} — macOS arm64.
+
+            ## First launch (one-time setup)
+
+            macOS will block the app the first time because Arc2Zen isn't
+            notarized. To allow it:
+
+            1. Double-click `Arc2Zen.app` — macOS shows a "damaged" or
+               "cannot verify" dialog. Click **Done**.
+            2. Open **System Settings → Privacy & Security**.
+            3. Scroll down and click **Open Anyway** next to the message
+               about Arc2Zen.
+            4. Enter your Mac password if prompted.
+            5. Click **Open Anyway** in the final confirmation dialog.
+
+            macOS only asks once — after that the app opens normally.
+
+            Full instructions are also inside the DMG as `INSTRUCTIONS.txt`.
+          files: |
+            dist/Arc2Zen-*.dmg
+            build/INSTRUCTIONS.txt
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,14 +15,11 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    runs-on: macos-14            # arm64 runner
-    timeout-minutes: 25
-
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Resolve version
         id: ver
         env:
@@ -35,12 +32,19 @@ jobs:
           else
             VERSION="${REF_NAME#v}"
           fi
-          # Reject anything that isn't dotted-numeric-with-optional-suffix.
           if ! [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+)*([.-][A-Za-z0-9]+)*$ ]]; then
             echo "::error::Refusing version '$VERSION' (must be like 1.2.3 or 1.2.3-rc1)"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  build-macos:
+    needs: resolve-version
+    runs-on: macos-14
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -69,7 +73,7 @@ jobs:
           PID=$!
           sleep 5
           if ! kill -0 $PID 2>/dev/null; then
-            echo "::error::Bundle exited prematurely on launch"
+            echo "::error::macOS bundle exited prematurely on launch"
             exit 1
           fi
           osascript -e 'tell application "Arc2Zen" to quit' || kill $PID
@@ -77,24 +81,106 @@ jobs:
 
       - name: Build .dmg
         env:
-          VERSION: ${{ steps.ver.outputs.version }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
         run: bash build/make_dmg.sh
 
-      - name: Upload DMG artifact (workflow_dispatch only)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Arc2Zen-${{ steps.ver.outputs.version }}-arm64
+          name: macos-dmg
           path: dist/Arc2Zen-*.dmg
+          if-no-files-found: error
+
+  build-windows:
+    needs: resolve-version
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-build.txt
+        shell: pwsh
+
+      - name: Render app icon
+        run: pwsh -NoProfile -File build/make_iconset.ps1
+        shell: pwsh
+
+      - name: Build .exe
+        run: pwsh -NoProfile -File build/make_exe.ps1
+        shell: pwsh
+
+      - name: Smoke-test the bundle
+        # Launch the .exe, wait ~5 s, ensure the process is still alive,
+        # then stop it. Catches missing PyInstaller hidden imports
+        # (clr_loader, pythonnet) that crash on first window create.
+        run: |
+          $proc = Start-Process -FilePath "dist/Arc2Zen/Arc2Zen.exe" -PassThru
+          Start-Sleep -Seconds 5
+          if ($proc.HasExited) {
+            Write-Error "Windows bundle exited prematurely (exit code $($proc.ExitCode))"
+            exit 1
+          }
+          Stop-Process -Id $proc.Id -Force
+        shell: pwsh
+
+      - name: Build .zip
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: pwsh -NoProfile -File build/make_zip.ps1
+        shell: pwsh
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-zip
+          path: dist/Arc2Zen-*.zip
+          if-no-files-found: error
+
+  release:
+    needs: [resolve-version, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-dmg
+          path: artifacts/
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-zip
+          path: artifacts/
+
+      - name: Stage release files
+        run: |
+          ls -la artifacts/
+          cp build/INSTRUCTIONS.txt artifacts/
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          name: Arc2Zen ${{ steps.ver.outputs.version }}
+          name: Arc2Zen ${{ needs.resolve-version.outputs.version }}
           body: |
-            Arc2Zen ${{ steps.ver.outputs.version }} — macOS arm64.
+            Arc2Zen ${{ needs.resolve-version.outputs.version }}
+
+            **macOS (Apple Silicon):** download `Arc2Zen-*-arm64.dmg`.
+            **Windows (x64):** download `Arc2Zen-*-win-x64.zip`.
 
             ## First launch (one-time setup)
 
@@ -109,10 +195,17 @@ jobs:
             4. Enter your Mac password if prompted.
             5. Click **Open Anyway** in the final confirmation dialog.
 
-            macOS only asks once — after that the app opens normally.
+            On Windows: right-click the downloaded `.zip` → **Properties**
+            → **Unblock** → OK before extracting (this strips the
+            Mark-of-the-Web from every file inside in one shot). After
+            extracting, double-click `Arc2Zen.exe`. SmartScreen may show
+            "Windows protected your PC" — click **More info** → **Run
+            anyway**.
 
-            Full instructions are also inside the DMG as `INSTRUCTIONS.txt`.
+            Full instructions are also bundled inside each artifact as
+            `INSTRUCTIONS.txt`.
           files: |
-            dist/Arc2Zen-*.dmg
-            build/INSTRUCTIONS.txt
+            artifacts/Arc2Zen-*.dmg
+            artifacts/Arc2Zen-*.zip
+            artifacts/INSTRUCTIONS.txt
           fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@ __pycache__/
 *.pyo
 *.pyd
 .Python
-build/
 develop-eggs/
-dist/
 downloads/
 eggs/
 .eggs/
@@ -19,6 +17,19 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+
+# PyInstaller / packaging output (the .app, .dmg, transient build cache).
+# Note: our `build/` directory at the repo root holds source build scripts
+# (spec, shell scripts) and is committed; the `build/arc2zen/` subdir that
+# PyInstaller generates is not.
+dist/
+/build/arc2zen/
+/build/__pycache__/
+*.spec.bak
+
+# Generated app icon. Re-rendered locally via build/make_iconset.sh and on
+# CI before each release, so it doesn't need to be checked in.
+app/assets/icon.icns
 
 # Virtual environments
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,11 @@ dist/
 /build/__pycache__/
 *.spec.bak
 
-# Generated app icon. Re-rendered locally via build/make_iconset.sh and on
-# CI before each release, so it doesn't need to be checked in.
+# Generated app icons. Re-rendered locally via build/make_iconset.sh
+# (macOS) or build/make_iconset.ps1 (Windows), and on CI before each
+# release, so they don't need to be checked in.
 app/assets/icon.icns
+app/assets/icon.ico
 
 # Virtual environments
 venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ python3 migrate_arc_to_zen.py --dry-run
 python3 migrate_arc_to_zen.py --verbose
 ```
 
+### GUI App
+
+```bash
+# Launch the PyWebView GUI (macOS)
+python -m app
+
+# Dev mode (opens WebKit DevTools)
+python -m app --debug
+```
+
 ### Component Testing
 
 ```bash
@@ -63,6 +73,33 @@ python3 src/zen_workspace_mapper.py
 - `zen_space_importer.py` - Manages containers in `containers.json`
 - `zen_bookmark_importer.py` - Backup import as Firefox bookmarks
 - `zen_sessionstore_manager.py` - Manages `zen-sessions.jsonlz4` for open tabs
+- `zen_sessions_importer.py` - Modern Zen 1.18+ session writes
+- `zen_favicon_importer.py` - Arc favicons → Zen `favicons.sqlite` plus inline session image
+- `arc_history_importer.py` - Arc browsing history → Zen `places.sqlite`
+- `arc_cookies_importer.py` - Arc cookies (decrypted via macOS Keychain) → Zen `cookies.sqlite`
+
+**GUI App (`app/`)**
+
+The `app/` directory wraps the importer classes with a PyWebView-based
+single-window GUI. Architecture:
+
+- `app/orchestrator.py` — `MigrationOrchestrator` facade. Calls the
+  importer classes in `src/` in sequence and emits structured
+  `ProgressEvent` dicts through a `ProgressBus`.
+- `app/progress_bus.py` — `logging.Handler` subclass that pushes log
+  records onto a queue the JS frontend polls every 120 ms. Lets the
+  importers stay unchanged while the GUI gets streaming progress.
+- `app/env_check.py` — Arc/Zen detection, profile listing,
+  browser-running check.
+- `app/browser_control.py` — AppleScript-based `quit_browser()` and
+  `launch_zen()`.
+- `app/bridge.py` — JS bridge methods reachable as
+  `window.pywebview.api.<method>`. Includes backup management
+  (`list_backups`, `restore_backup`, `delete_backup`).
+- `app/window.py` — PyWebView frameless-with-vibrancy window setup,
+  `easy_drag=True` for native window dragging.
+- `app/frontend/` — vanilla HTML + CSS + JS (no build step). Uses
+  `createElement` exclusively (no `innerHTML` with user data).
 
 ### Data Flow
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Arc → Zen
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![Platform](https://img.shields.io/badge/platform-macOS%20arm64-lightgrey?logo=apple)](https://github.com/rafcabezas/arc2zen/releases/latest)
+[![Platform](https://img.shields.io/badge/platform-macOS%20arm64%20%7C%20Windows%20x64-lightgrey?logo=apple)](https://github.com/rafcabezas/arc2zen/releases/latest)
 [![Python](https://img.shields.io/badge/python-3.7%2B-yellow?logo=python&logoColor=white)](https://www.python.org/)
 [![PyWebView](https://img.shields.io/badge/GUI-PyWebView-5e86ff)](https://pywebview.flowrl.com/)
 [![Latest release](https://img.shields.io/github/v/release/rafcabezas/arc2zen?display_name=tag&label=release)](./releases/latest)
@@ -15,10 +15,14 @@ terminal, no Python, no install steps to follow.
 
 ---
 
-## Install (macOS, Apple Silicon)
+## Install
 
-1. Open the [latest release](./releases/latest) and download
-   `Arc2Zen-x.y.z-arm64.dmg`.
+Open the [latest release](./releases/latest) and pick the artifact
+for your OS.
+
+### macOS (Apple Silicon)
+
+1. Download `Arc2Zen-x.y.z-arm64.dmg`.
 2. Double-click the DMG to mount it, then double-click `Arc2Zen.app`.
 3. macOS will show a dialog ("damaged" or "cannot verify"). Click
    **Done**. Do **not** click "Move to Trash".
@@ -30,20 +34,37 @@ terminal, no Python, no install steps to follow.
 
 The app launches and walks you through detection, preview, and
 migration. Steps 3 to 7 only happen the first time. After that you can
-double-click `Arc2Zen.app` normally.
+double-click `Arc2Zen.app` normally. When you're done, drag the DMG to
+the Trash; Arc2Zen runs from inside the DMG and doesn't install itself
+anywhere.
 
-When you're done, drag the DMG to the Trash. Arc2Zen runs from inside
-the DMG and doesn't install itself anywhere.
+### Windows (x64)
 
-> **Why all the steps?** Apple charges $99/year for the developer
-> certificate that removes this prompt. Arc2Zen is free open-source
-> software and that fee isn't worth passing on. The bundle is ad-hoc
-> codesigned, so you can verify its contents have not been tampered
-> with at any time:
+1. Download `Arc2Zen-x.y.z-win-x64.zip`.
+2. **Before extracting**, right-click the .zip in your Downloads
+   folder and choose **Properties**. Tick the **Unblock** checkbox at
+   the bottom and click OK. (This strips the Mark-of-the-Web tag from
+   every file inside in one shot. If you skip this step, every .dll
+   inside the bundle trips SmartScreen separately.)
+3. Double-click the .zip and drag the `Arc2Zen` folder anywhere.
+4. Open the `Arc2Zen` folder and double-click `Arc2Zen.exe`.
+5. Windows will show *"Windows protected your PC"*. Click **More
+   info**, then **Run anyway**.
+
+The app launches. When you're done, drag the `Arc2Zen` folder to the
+Recycle Bin; nothing else needs to be uninstalled.
+
+> **Why all the steps?** Apple and Microsoft each charge developers
+> for the certificates that remove these prompts. Arc2Zen is free
+> open-source software and those fees aren't worth passing on. The
+> macOS bundle is ad-hoc codesigned, so you can verify its contents
+> have not been tampered with at any time:
 >
 > ```
 > codesign --verify --deep --strict /Volumes/Arc2Zen/Arc2Zen.app
 > ```
+>
+> Both platforms are reproducible from source: see [`build/`](./build).
 
 ### Don't have Zen yet?
 
@@ -65,7 +86,7 @@ your profile, then click **Recheck** in Arc2Zen and continue.
 | **Bookmarks** | Pinned tabs are also mirrored to Firefox bookmarks as a backup. |
 | **Favicons** | Arc's cached icons are inlined so tabs show their icons immediately, with no waiting for refetch. |
 | **History** | Optional. Browsing history with original timestamps is copied over. |
-| **Login state** | Optional, macOS only. Arc cookies are decrypted (one-time Keychain prompt) and re-encrypted into Zen so you stay logged in to Gmail, Twitter, and the rest. |
+| **Login state** | Optional. Arc cookies are decrypted (via macOS Keychain or Windows DPAPI, depending on platform) and re-encrypted into Zen so you stay logged in to Gmail, Twitter, and the rest. |
 
 Every step writes a timestamped backup beside your Zen profile before
 it changes anything, and Arc data is read-only. The Backups screen
@@ -86,7 +107,7 @@ pip install -r requirements.txt
 python3 migrate_arc_to_zen.py --dry-run    # preview only
 python3 migrate_arc_to_zen.py              # actual migration
 
-# GUI (macOS only)
+# GUI (macOS or Windows)
 pip install -r requirements-build.txt
 python -m app
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A complete Python-based migration tool that converts Arc browser spaces, pinned tabs, and open tabs into Zen browser workspaces with proper tab assignment.
 
+## 🖥️ GUI app (macOS)
+
+A polished single-window app wraps the migration tool. Welcome screen,
+browser detection with one-click quit, preview of what will be migrated,
+live progress with per-step detail, success/error screens, and a backup
+manager for restoring or deleting backup files.
+
+```bash
+# From the repo root
+pip install -r requirements.txt pywebview
+python -m app
+```
+
+The same code path that powers the CLI is used by the GUI: the
+`MigrationOrchestrator` facade in `app/orchestrator.py` wraps the importer
+classes in `src/` without modifying them, and structured progress events
+are pushed through a `logging.Handler` that the JS frontend polls. See
+`app/` for the source.
+
 ## 🚀 Quick Start
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -1,350 +1,205 @@
-# Arc to Zen Browser Migration Tool
+# Arc → Zen
 
-A complete Python-based migration tool that converts Arc browser spaces, pinned tabs, and open tabs into Zen browser workspaces with proper tab assignment.
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Platform](https://img.shields.io/badge/platform-macOS%20arm64-lightgrey?logo=apple)](https://github.com/rafcabezas/arc2zen/releases/latest)
+[![Python](https://img.shields.io/badge/python-3.7%2B-yellow?logo=python&logoColor=white)](https://www.python.org/)
+[![PyWebView](https://img.shields.io/badge/GUI-PyWebView-5e86ff)](https://pywebview.flowrl.com/)
+[![Latest release](https://img.shields.io/github/v/release/rafcabezas/arc2zen?display_name=tag&label=release)](./releases/latest)
 
-## 🖥️ GUI app (macOS)
+Move your Arc browser setup to [Zen Browser](https://zen-browser.app/)
+in under a minute. Workspaces, pinned tabs, folders, bookmarks, browsing
+history, and login state, all carried across.
 
-A polished single-window app wraps the migration tool. Welcome screen,
-browser detection with one-click quit, preview of what will be migrated,
-live progress with per-step detail, success/error screens, and a backup
-manager for restoring or deleting backup files.
+A polished single-window app handles the whole migration for you. No
+terminal, no Python, no install steps to follow.
 
-```bash
-# From the repo root
-pip install -r requirements.txt pywebview
-python -m app
-```
+---
 
-The same code path that powers the CLI is used by the GUI: the
-`MigrationOrchestrator` facade in `app/orchestrator.py` wraps the importer
-classes in `src/` without modifying them, and structured progress events
-are pushed through a `logging.Handler` that the JS frontend polls. See
-`app/` for the source.
+## Install (macOS, Apple Silicon)
 
-## 🚀 Quick Start
+1. Open the [latest release](./releases/latest) and download
+   `Arc2Zen-x.y.z-arm64.dmg`.
+2. Double-click the DMG to mount it, then double-click `Arc2Zen.app`.
+3. macOS will show a dialog ("damaged" or "cannot verify"). Click
+   **Done**. Do **not** click "Move to Trash".
+4. Open  → **System Settings** → **Privacy & Security**.
+5. Scroll the right pane until you see *"Arc2Zen was blocked to
+   protect your Mac."* Click **Open Anyway**.
+6. Enter your Mac password if prompted.
+7. macOS shows one final confirmation. Click **Open Anyway**.
 
-### Prerequisites
+The app launches and walks you through detection, preview, and
+migration. Steps 3 to 7 only happen the first time. After that you can
+double-click `Arc2Zen.app` normally.
 
-- **Python 3.7+**
-- **Arc Browser** (with spaces and pinned tabs you want to migrate)
-- **Zen Browser** (installed and run at least once)
-- **macOS** or **Windows** (current implementation)
-- **lz4** Python package (for session tab injection): `pip install lz4`
+When you're done, drag the DMG to the Trash. Arc2Zen runs from inside
+the DMG and doesn't install itself anywhere.
 
-### Installation
+> **Why all the steps?** Apple charges $99/year for the developer
+> certificate that removes this prompt. Arc2Zen is free open-source
+> software and that fee isn't worth passing on. The bundle is ad-hoc
+> codesigned, so you can verify its contents have not been tampered
+> with at any time:
+>
+> ```
+> codesign --verify --deep --strict /Volumes/Arc2Zen/Arc2Zen.app
+> ```
 
-1. Clone this repository:
+### Don't have Zen yet?
+
+If Zen Browser isn't installed yet, the detection screen offers a
+**Download Zen** button. Install Zen, launch it once so it creates
+your profile, then click **Recheck** in Arc2Zen and continue.
+
+---
+
+## What gets migrated
+
+| | |
+| --- | --- |
+| **Spaces** | Each Arc space becomes a Zen workspace, with its emoji icon and colour theme. |
+| **Pinned tabs** | All pinned tabs land on the matching workspace, in their original order. |
+| **Folders** | The full nested folder hierarchy is preserved, collapsed by default to keep your sidebar clean. |
+| **Essential tabs** | Arc's top-toolbar Essentials become pinned tabs on the right space. |
+| **Open tabs** | Optional. Live tabs become real Zen tabs. |
+| **Bookmarks** | Pinned tabs are also mirrored to Firefox bookmarks as a backup. |
+| **Favicons** | Arc's cached icons are inlined so tabs show their icons immediately, with no waiting for refetch. |
+| **History** | Optional. Browsing history with original timestamps is copied over. |
+| **Login state** | Optional, macOS only. Arc cookies are decrypted (one-time Keychain prompt) and re-encrypted into Zen so you stay logged in to Gmail, Twitter, and the rest. |
+
+Every step writes a timestamped backup beside your Zen profile before
+it changes anything, and Arc data is read-only. The Backups screen
+inside the app lets you restore or delete those backups any time.
+
+---
+
+## Run from source
+
+For Linux, Intel Mac, contributors, or anyone who'd rather skip the DMG:
+
 ```bash
 git clone https://github.com/rafcabezas/arc2zen.git
 cd arc2zen
+pip install -r requirements.txt
+
+# CLI
+python3 migrate_arc_to_zen.py --dry-run    # preview only
+python3 migrate_arc_to_zen.py              # actual migration
+
+# GUI (macOS only)
+pip install -r requirements-build.txt
+python -m app
 ```
 
-2. Install the optional dependency for session tab injection:
-```bash
-pip install lz4
-```
+The CLI accepts `--zen-profile NAME`, `--arc-space NAME`,
+`--folders-open`, `--skip-favicons`, `--open-tabs`, `--verbose`, and
+`--dry-run`. Use `python3 migrate_arc_to_zen.py --help` for the full
+list.
 
-### Basic Usage
-
-Run the complete migration (recommended for first-time users):
-
-```bash
-# Dry run first to see what will be migrated
-python3 migrate_arc_to_zen.py --dry-run
-
-# If everything looks good, run the actual migration
-python3 migrate_arc_to_zen.py
-
-# Then inject all tabs into the session file (makes tabs actually appear)
-python3 inject_session_tabs.py
-```
-
-### Important: Session Tab Injection
-
-After running the main migration, tabs may only appear as bookmarks or metadata.
-To make them show up as **real browser tabs** in Zen's sidebar, run:
+Individual importers can be run on their own. They are all idempotent
+and produce timestamped backups:
 
 ```bash
-# Migrate with custom settings
-python3 migrate_arc_to_zen.py --zen-profile "Default" --verbose
+python3 src/arc_history_importer.py --zen-profile "Default (release)"
+python3 src/arc_cookies_importer.py --zen-profile "Default (release)"
+python3 src/zen_favicon_importer.py --zen-profile "Default (release)"
 ```
 
-This writes directly to `zen-sessions.jsonlz4`, which is the file Zen actually
-reads to render tabs. The script is idempotent — re-running it replaces
-previously-injected tabs with a fresh extraction.
+---
 
-### Advanced Usage
+## How it works
+
+The migration runs as a fixed pipeline of independent importers, each
+of which reads Arc data through a snapshot copy of the source SQLite
+file (so Arc itself is never touched) and writes to its corresponding
+Zen file with a backup taken first.
+
+| Step | Reads (Arc) | Writes (Zen) |
+| --- | --- | --- |
+| Spaces & pinned tabs | `StorableSidebar.json` | `zen-sessions.jsonlz4`, `containers.json` |
+| Bookmarks | `StorableSidebar.json` | `places.sqlite` |
+| Favicons | `Default/Favicons` | `favicons.sqlite`, plus inline `image` data URIs in `zen-sessions.jsonlz4` |
+| History | `Default/History` | `places.sqlite` |
+| Cookies | `Default/Cookies` (AES-128-CBC, key from macOS Keychain) | `cookies.sqlite` (incl. all per-space containers) |
+
+A few things that took some reverse-engineering and might be useful if
+you're hacking on this:
+
+- **Firefox `places::HashURL`** is the 48-bit hash function used in
+  `moz_places.url_hash`, `moz_pages_w_icons.page_url_hash`, and
+  `moz_icons.fixed_icon_url_hash`. Implementation in
+  `src/zen_favicon_importer.py`.
+- **Modern Zen renders pinned-tab favicons from each tab's inline
+  `image` data URI in `zen-sessions.jsonlz4`**, not from
+  `favicons.sqlite`. Writing only the SQLite store leaves the sidebar
+  blank.
+- **`moz_cookies.expiry` switched from seconds to milliseconds around
+  Firefox 108.** Storing seconds makes Firefox treat every cookie as
+  expired in 1970 and purge them all on next startup.
+- **Cookies in container tabs are isolated.** Cookies imported with
+  empty `originAttributes` are invisible to per-space containers, so
+  each cookie is also written under `^userContextId=N` for every
+  container the migration creates.
+
+The GUI in `app/` wraps the same importer classes from `src/` without
+modifying them. Architecture details are in [CLAUDE.md](./CLAUDE.md).
+
+---
+
+## Troubleshooting
+
+- **"Zen profile not found"**: launch Zen once so it creates the
+  profile, then click Recheck.
+- **"No Arc data found"**: make sure Arc has been opened at least
+  once and has at least one pinned tab.
+- **Cookies didn't carry over**: close Zen completely before running
+  (Firefox holds an exclusive lock on `cookies.sqlite` while open) and
+  approve the Keychain prompt that appears on first run.
+- **Something looks wrong after migration**: open the **Backups**
+  screen in the app and restore the most recent backup of the relevant
+  file. Or close Zen and copy any of the `*.backup.<timestamp>` files
+  in your Zen profile directory back over the live file.
+
+For anything else, [open an issue](./issues).
+
+---
+
+## Contributing
+
+Pull requests welcome. The codebase is plain Python 3.7+ with a single
+runtime dependency (`lz4`) plus `cryptography` for the cookies path.
+The GUI uses PyWebView (Python) + vanilla HTML/CSS/JS with no build
+step.
 
 ```bash
-# Migrate only a specific Arc space
-python3 migrate_arc_to_zen.py --arc-space "Personal"
-python3 migrate_arc_to_zen.py --arc-space "Work" --dry-run
-
-# Specify Zen profile
-python3 migrate_arc_to_zen.py --zen-profile "Default"
-
-# Also migrate open tabs via sessionstore (legacy approach)
-python3 migrate_arc_to_zen.py --open-tabs
-
-# Verbose logging
-python3 migrate_arc_to_zen.py --verbose
-
-# See all available options
-python3 migrate_arc_to_zen.py --help
+git clone https://github.com/rafcabezas/arc2zen.git
+cd arc2zen
+pip install -r requirements.txt -r requirements-build.txt
+python3 migrate_arc_to_zen.py --dry-run --verbose   # CLI smoke test
+python -m app --debug                               # GUI with WebKit DevTools
 ```
 
-## 📋 What Gets Migrated
-
-- **Arc Spaces** → **Zen Workspaces** (each Arc space becomes a Zen workspace)
-- **Space Icons** → **Workspace Icons** (Unicode emojis preserved: 🏠, 🌳, 🎬, ⚖️, etc.)
-- **Space Colors** → **Workspace Themes** (Arc's subtle color tints accurately reproduced)
-- **Pinned Tabs** → **Zen Pinned Tabs** (with folder structure preserved)
-- **Essential Tabs** → **Essential Pinned Tabs** (Arc's top toolbar tabs with large icons)
-- **Open Tabs** → **Zen Open Tabs** (unpinned tabs restored as real browser tabs)
-- **Folder Hierarchy** → **Zen Folder Structure** (nested folders maintained)
-- **Display Order** → **Zen Sidebar Order** (Arc visual ordering preserved)
-- **Backup Bookmarks** → **Firefox Bookmarks** (additional backup as standard bookmarks)
-- **Favicons** → **Zen Favicons** (Arc's cached icons copied so tabs show their icons immediately, both as inline `image` data URIs in the session and in `favicons.sqlite`)
-- **History** → **Zen History** (browsing history with visit timestamps preserved; via `arc_history_importer.py`)
-- **Cookies** → **Zen Cookies** (decrypted using the macOS Keychain "Arc Safe Storage" key; cookies are also duplicated into the per-space containers so logins work in container tabs; via `arc_cookies_importer.py`)
-
-## 🆕 New in this fork
-
-- Favicons import (no more grey blank icons after migration)
-- Folders import collapsed by default — pass `--folders-open` for the previous behaviour
-- Space emoji icons and Arc color themes properly carried into Zen workspaces
-- Standalone `arc_history_importer.py` and `arc_cookies_importer.py` for history and cookies (macOS only for cookies)
-
-## 🔧 How It Works
-
-### Step 1: Analyze Your Arc Data
-The tool reads Arc's `StorableSidebar.json` to extract:
-- Space names, structure, and icons (Unicode emojis when available)
-- Pinned tabs with URLs and metadata
-- Open (unpinned) tabs per space
-- Folder hierarchy within each space
-- Visual ordering using container childrenIds
-
-### Step 2: Map Workspaces
-The tool helps you map Arc spaces to Zen workspaces:
-```bash
-python3 src/zen_workspace_mapper.py
-```
-This creates a mapping guide showing which Zen workspace UUID corresponds to each Arc space.
-
-### Step 3: Import Pinned Tabs & Workspaces
-For **Zen 1.18+**, spaces, pinned tabs, and folders are written directly to `zen-sessions.jsonlz4` — the modern storage format for Zen's sidebar. For older Zen versions, the tool falls back to the legacy `zen_pins` and `zen_workspaces` SQLite tables.
-
-## 🛡️ Safety Features
-
-- **Read-only Arc access** - Your Arc data is never modified
-- **Automatic backups** - Zen database is backed up before any changes
-- **Dry-run mode** - Test migration without making changes
-- **Validation** - Data integrity checks throughout the process
-
-## 📁 File Structure
-
-```
-arc2zen/
-├── migrate_arc_to_zen.py              # Main migration script
-├── requirements.txt                   # Python dependencies (lz4)
-├── src/
-│   ├── arc_pinned_tab_extractor.py    # Extract Arc pinned tabs
-│   ├── arc_bookmark_extractor.py      # Extract Arc bookmarks
-│   ├── arc_profile_discovery.py       # Locate Arc profiles
-│   ├── zen_sessions_importer.py       # Import to zen-sessions.jsonlz4 (Zen 1.18+)
-│   ├── zen_sessionstore_manager.py    # Read/write mozlz4 sessionstore
-│   ├── zen_pinned_tab_importer.py     # Legacy: import tabs to zen_pins table
-│   ├── zen_workspace_importer.py      # Legacy: create zen_workspaces entries
-│   ├── zen_space_importer.py          # Create Zen containers for spaces
-│   ├── zen_bookmark_importer.py       # Backup import as Firefox bookmarks
-│   ├── zen_workspace_mapper.py        # Map Arc spaces to Zen workspaces
-│   └── zen_schema_analyzer.py         # Analyze Zen database schema
-├── .gitignore                         # Excludes generated files
-└── README.md                          # This file
-```
-
-## 🔍 Detailed Usage
-
-### Workspace Mapping
-
-Before running the full migration, you may want to map your Arc spaces to Zen workspaces:
+To produce a `.dmg` locally:
 
 ```bash
-python3 src/zen_workspace_mapper.py
+bash build/make_app.sh   # produces dist/Arc2Zen.app
+bash build/make_dmg.sh   # produces dist/Arc2Zen-<version>-arm64.dmg
 ```
 
-This interactive script will:
-1. Analyze your current Zen workspace structure
-2. Ask for your Arc space names (or detect them automatically)
-3. Create a mapping guide at `workspace_uuid_mapping.json`
-4. Show you which UUID corresponds to each workspace
+CI builds happen automatically on every `v*` git tag via
+[`.github/workflows/release.yml`](./.github/workflows/release.yml).
 
-### Individual Components
+---
 
-You can also run individual components:
+## License
 
-```bash
-# Extract Arc pinned tabs only
-python3 src/arc_pinned_tab_extractor.py
+MIT, see [LICENSE](./LICENSE).
 
-# Analyze Zen database schema
-python3 src/zen_schema_analyzer.py
+Always back up your data before running migrations. Use at your own
+risk.
 
-# Import pinned tabs to Zen (advanced usage)
-python3 src/zen_pinned_tab_importer.py --dry-run
-```
+## Acknowledgements
 
-## ⚙️ Configuration
-
-### Command Line Options
-
-- `--dry-run` - Test migration without making changes
-- `--zen-profile NAME` - Specify target Zen profile name
-- `--arc-space NAME` - Migrate only a specific Arc space by name (case-insensitive partial matching). If not specified, all spaces are migrated.
-- `--verbose` - Enable detailed debug logging
-- `--help` - Show all available options
-
-### Generated Files
-
-The tool creates several files during migration (all excluded from git):
-
-- `arc_bookmarks_export.json` - Extracted Arc pinned tabs
-- `arc_pinned_tabs_export.json` - Arc pinned tabs with workspace info
-- `workspace_uuid_mapping.json` - Mapping between Arc spaces and Zen workspaces
-- `*.backup.*` - Database backups
-
-## 🎯 Arc Display Order Solution
-
-**✅ Improved**: The migration tool preserves Arc's visual ordering using Arc's internal container structure.
-
-**Technical Solution**: Arc stores display order in each space's pinned container `childrenIds` array, which contains items in visual order. The migration tool uses this data structure to maintain ordering fidelity.
-
-**Result**: Folders and tabs appear in Zen in a similar order to your Arc sidebar.
-
-## 🎨 Visual Migration Features
-
-### Space Icon Migration
-**✅ Implemented**: Arc space icons migrate to Zen workspaces as Unicode emojis.
-
-**Technical Solution**: Extracts Unicode emojis from Arc's `customInfo.iconType.emoji_v2` field and preserves them in Zen workspace definitions.
-
-**Result**: Arc space icons (🏠, 🌳, 🎬, ⚖️, etc.) appear as visual icons in Zen workspaces.
-
-### Space Color Migration
-**✅ Implemented**: Arc space colors migrate as subtle workspace themes with pixel-perfect accuracy.
-
-**Technical Solution**:
-- Extracts RGB values from Arc's `customInfo.windowTheme.primaryColorPalette.midTone`
-- Uses measured Arc color values (e.g., Personal green: #bbf6da, WillowTree gold: #fbe496)
-- Applies Arc's exact color transformation algorithm to create matching subtle tints
-- Stores as JSON theme data in Zen's workspace theme system (`theme_type`, `theme_colors`)
-
-**Result**: Zen workspace backgrounds closely match Arc's subtle color aesthetics.
-
-### Essential Tabs Migration
-**✅ Implemented**: Arc's Essential tabs (top toolbar) migrate to appropriate workspaces.
-
-**Technical Solution**:
-- Extracts Essential tabs from Arc's `topApps` containers per profile
-- Maps tabs to correct workspaces using profile associations (`directoryBasename`)
-- Imports with `is_essential` flag to distinguish from regular pinned tabs
-
-**Result**: Arc's Essential tabs appear as pinned tabs in their respective Zen workspaces.
-
-## ⚠️ Minor Limitations
-
-### Folder Visual Styles
-- Arc's custom folder icons/colors are not preserved (Zen uses its own folder styling)
-- All folder hierarchy and content relationships are maintained
-
-### Browser-Specific Features
-- Arc-specific features (like Boosts, Easels) don't have Zen equivalents and are not migrated
-- Standard web content, bookmarks, and organizational structure migrate completely
-
-### What's Now Supported ✅
-- **Space icons**: Arc space emojis migrate as Unicode icons in Zen
-- **Space colors**: Arc color themes migrate as Zen workspace themes
-- **Essential tabs**: Arc's top toolbar tabs migrate to appropriate workspaces
-- **Display ordering**: Arc sidebar ordering preserved via container childrenIds
-- **Folder hierarchy**: Nested folder structure maintained
-- **Workspace mapping**: Arc space → Zen workspace conversion
-
-## 🐛 Troubleshooting
-
-### Common Issues
-
-**"Zen profile not found"**
-- Make sure Zen browser has been run at least once
-- Check that the profile directory exists at `~/Library/Application Support/zen/Profiles/`
-
-**"No Arc data found"**
-- Verify Arc browser is installed
-- Check that you have spaces with pinned tabs
-
-**Workspace mapping issues**
-- Run `python3 src/zen_workspace_mapper.py` to manually map spaces
-- Update the generated `workspace_uuid_mapping.json` file
-
-### Data Recovery
-
-If anything goes wrong:
-1. The tool creates automatic backups of your Zen database
-2. You can restore from the `.backup` files
-3. Your Arc data remains unchanged (read-only access)
-
-## 🔬 Technical Details
-
-### Arc Browser Structure
-- **Location**: `~/Library/Application Support/Arc/` (macOS)
-- **Format**: Chromium-based with Arc-specific extensions
-- **Key File**: `StorableSidebar.json` contains spaces, pinned tabs, and folder hierarchy
-- **Container ordering**: Each space has `containerIDs: ['pinned', uuid, 'unpinned', uuid]`
-  where the UUID immediately following each marker stores that category's `childrenIds`
-  in exact visual order. The marker order can vary (pinned-first or unpinned-first).
-
-### Zen Browser Structure
-- **Location**: `~/Library/Application Support/zen/Profiles/[profile]/` (macOS)
-- **Format**: Firefox-based
-- **Key Files**:
-  - `zen-sessions.jsonlz4` (Zen 1.18+: spaces, pinned tabs, folders)
-  - `places.sqlite` (bookmarks database)
-  - `containers.json` (workspace container definitions)
-  - `prefs.js` (preferences)
-
-### Storage Formats
-- **Zen 1.18+**: `zen-sessions.jsonlz4` — mozlz4-compressed JSON containing spaces, tabs, and folders
-- **Legacy Zen**: `zen_pins` and `zen_workspaces` SQLite tables in `places.sqlite`
-- **Bookmarks**: Standard Firefox `moz_bookmarks`/`moz_places` tables (used as backup)
-
-## 🤝 Contributing
-
-Contributions are welcome! This is an open source tool for the community.
-
-### Development Setup
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request
-
-### Testing
-
-Always test with dry-run first:
-```bash
-python3 migrate_arc_to_zen.py --dry-run --verbose
-```
-
-## 📄 License
-
-MIT License - See LICENSE file for details.
-
-**⚠️ Important**: Always backup your data before running migrations. Use at your own risk.
-
-## 🙏 Acknowledgments
-
-- Arc Browser team for creating an innovative browser
-- Zen Browser team for building a privacy-focused alternative
-- The open source community for inspiration and tools
-- Claude Code for AI-assisted development and debugging
+- Arc Browser team for the original product.
+- Zen Browser team for the privacy-focused alternative.
+- The open source community for inspiration and tools.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ python3 migrate_arc_to_zen.py --help
 - **Folder Hierarchy** → **Zen Folder Structure** (nested folders maintained)
 - **Display Order** → **Zen Sidebar Order** (Arc visual ordering preserved)
 - **Backup Bookmarks** → **Firefox Bookmarks** (additional backup as standard bookmarks)
+- **Favicons** → **Zen Favicons** (Arc's cached icons copied so tabs show their icons immediately, both as inline `image` data URIs in the session and in `favicons.sqlite`)
+- **History** → **Zen History** (browsing history with visit timestamps preserved; via `arc_history_importer.py`)
+- **Cookies** → **Zen Cookies** (decrypted using the macOS Keychain "Arc Safe Storage" key; cookies are also duplicated into the per-space containers so logins work in container tabs; via `arc_cookies_importer.py`)
+
+## 🆕 New in this fork
+
+- Favicons import (no more grey blank icons after migration)
+- Folders import collapsed by default — pass `--folders-open` for the previous behaviour
+- Space emoji icons and Arc color themes properly carried into Zen workspaces
+- Standalone `arc_history_importer.py` and `arc_cookies_importer.py` for history and cookies (macOS only for cookies)
 
 ## 🔧 How It Works
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,17 +1,37 @@
 """
 Entry point: ``python -m app``.
 
-In a PyInstaller-bundled .app this is invoked indirectly via the main script
-declared in the spec file.
+In a PyInstaller-bundled .app/.exe this is invoked indirectly via the main
+script declared in the spec file.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 
 from .window import launch
+
+
+def _set_windows_app_user_model_id() -> None:
+    """Tell Windows that this process is its own application.
+
+    Without this, the WebView2 host inherits Python's default AppUserModelID
+    and Windows groups every Arc2Zen launch under a generic "Python" entry
+    in the taskbar. Setting it makes the icon, taskbar grouping, and pin
+    behaviour all line up correctly.
+    """
+    if os.name != "nt":
+        return
+    try:
+        import ctypes
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            "com.arc2zen.app"
+        )
+    except Exception:
+        pass
 
 
 def main() -> int:
@@ -24,6 +44,7 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
+    _set_windows_app_user_model_id()
     launch(debug=args.debug)
     return 0
 

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,32 @@
+"""
+Entry point: ``python -m app``.
+
+In a PyInstaller-bundled .app this is invoked indirectly via the main script
+declared in the spec file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from .window import launch
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="arc2zen", description="Arc to Zen migration GUI")
+    parser.add_argument("--debug", action="store_true", help="Enable WebKit devtools and verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    launch(debug=args.debug)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/__version__.py
+++ b/app/__version__.py
@@ -9,4 +9,4 @@ Update this file when cutting a new tag; the matching ``v<version>``
 git tag triggers the GitHub Actions release workflow.
 """
 
-VERSION = "1.1.0"
+VERSION = "1.1.1"

--- a/app/__version__.py
+++ b/app/__version__.py
@@ -9,4 +9,4 @@ Update this file when cutting a new tag; the matching ``v<version>``
 git tag triggers the GitHub Actions release workflow.
 """
 
-VERSION = "1.1.1"
+VERSION = "1.1.2"

--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,0 +1,12 @@
+"""Single source of truth for the Arc2Zen app version.
+
+Imported by:
+- ``app.bridge.Bridge.version()`` so the frontend can render it.
+- ``build/arc2zen.spec`` so the macOS Info.plist and Windows file
+  metadata reflect the same value.
+
+Update this file when cutting a new tag; the matching ``v<version>``
+git tag triggers the GitHub Actions release workflow.
+"""
+
+VERSION = "1.1.0"

--- a/app/assets/icon.svg
+++ b/app/assets/icon.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <defs>
+    <!-- Outer macOS-style rounded-square card with subtle gradient -->
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1A1B22"/>
+      <stop offset="100%" stop-color="#0E0F14"/>
+    </linearGradient>
+    <!-- Arc badge (cream) -->
+    <linearGradient id="arcBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFF7F2"/>
+      <stop offset="60%" stop-color="#FFE9F0"/>
+      <stop offset="100%" stop-color="#FFD8E5"/>
+    </linearGradient>
+    <!-- Zen badge (gunmetal) -->
+    <linearGradient id="zenBg" x1="0" y1="0" x2="0.7" y2="1">
+      <stop offset="0%" stop-color="#2B2B2F"/>
+      <stop offset="70%" stop-color="#15151A"/>
+      <stop offset="100%" stop-color="#0B0B0E"/>
+    </linearGradient>
+    <filter id="cardShadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+
+  <!-- App background (rounded square, ~22% radius is the macOS standard) -->
+  <rect x="0" y="0" width="1024" height="1024" rx="225" ry="225" fill="url(#bg)"/>
+
+  <!-- Arc badge (left) -->
+  <g transform="translate(120 320)" filter="url(#cardShadow)">
+    <rect width="320" height="320" rx="68" ry="68" fill="url(#arcBg)"/>
+    <!-- The Arc Browser logo paths, viewBox 0 0 82 68, scaled and centred. -->
+    <g transform="translate(50 60) scale(2.7)" fill-rule="evenodd" clip-rule="evenodd">
+      <path fill="#1a007f" d="m28.8 51.97 6.35-13.36c-4.85-1.03-9.73-4.03-12.49-7.68l-6.64 13.96c3.69 3.13 8.12 5.59 12.78 7.08"/>
+      <path fill="#4e000a" d="M55.3 30.53c-3.19 3.91-7.62 6.81-12.36 7.94l6.33 13.32c4.62-1.56 8.94-4.08 12.67-7.31L55.3 30.53z"/>
+      <path fill="#1a007f" d="m16.02 44.89-3.32 6.98c-1.69 3.55-.42 7.92 3.06 9.77 3.69 1.96 8.23.43 10.01-3.3l3.03-6.37a37.885 37.885 0 0 1-12.78-7.08"/>
+      <path fill="#ff9396" d="M68.48 15.29a7.29 7.29 0 0 0-8.58 5.72c-.7 3.5-2.34 6.76-4.6 9.53l6.63 13.96c6.12-5.31 10.64-12.54 12.26-20.63.79-3.96-1.77-7.8-5.71-8.58"/>
+      <path fill="#002dc8" d="M42.94 38.47c-1.42.34-2.87.52-4.32.52-1.13 0-2.3-.13-3.47-.38-4.85-1.03-9.73-4.03-12.49-7.68-.69-.91-1.25-1.86-1.64-2.83-1.51-3.73-5.76-5.53-9.49-4.03C7.8 25.58 6 29.83 7.5 33.56c1.71 4.24 4.73 8.13 8.52 11.33a37.84 37.84 0 0 0 12.77 7.08c3.21 1.03 6.54 1.6 9.82 1.6 3.64 0 7.23-.63 10.65-1.78l-6.32-13.32z"/>
+      <path fill="#ff536a" d="m65.43 51.84-3.5-7.36-6.63-13.95-.01.01s0-.01.01-.01l-9.64-20.28a7.292 7.292 0 0 0-6.58-4.16c-2.81 0-5.37 1.62-6.58 4.16l-9.83 20.68c2.76 3.65 7.64 6.65 12.49 7.68l3.18-6.68c.3-.63 1.2-.63 1.5 0l3.11 6.54h.02-.02l6.33 13.32 3.11 6.54a7.28 7.28 0 0 0 6.59 4.16c.65 0 1.3-.09 1.94-.27 4.39-1.21 6.47-6.26 4.51-10.38"/>
+    </g>
+  </g>
+
+  <!-- Arrow between badges -->
+  <g transform="translate(512 480)" stroke="#FFFFFF" stroke-width="14" fill="none" stroke-linecap="round" stroke-linejoin="round" opacity="0.65">
+    <line x1="-30" y1="0" x2="30" y2="0"/>
+    <polyline points="10,-22 32,0 10,22"/>
+  </g>
+
+  <!-- Zen badge (right) -->
+  <g transform="translate(584 320)" filter="url(#cardShadow)">
+    <rect width="320" height="320" rx="68" ry="68" fill="url(#zenBg)"/>
+    <!-- Three concentric rings, hollow centre -->
+    <g transform="translate(160 160)" stroke="#F2F2F4" stroke-width="11" fill="none">
+      <circle r="118"/>
+      <circle r="78"/>
+      <circle r="38"/>
+    </g>
+  </g>
+</svg>

--- a/app/bridge.py
+++ b/app/bridge.py
@@ -1,0 +1,267 @@
+"""
+JavaScript bridge for the GUI.
+
+PyWebView passes the ``Bridge`` instance as ``js_api`` and every public method
+becomes callable from JS as ``window.pywebview.api.<method>``. All methods
+return JSON-serialisable values (or ``None``).
+
+Migration runs on a worker thread so the JS side can poll
+``drain_progress`` while the importers do their work. The orchestrator's
+``ProgressBus`` is the queue between them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+import time
+import traceback
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from .browser_control import launch_zen, open_in_finder, quit_browser
+from .env_check import env_report_to_dict
+from .orchestrator import (
+    GUI_STEPS,
+    STEP_LABELS,
+    MigrationOptions,
+    MigrationOrchestrator,
+    preview_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _safe(payload: Any) -> Any:
+    """Best-effort JSON sanitiser for return values."""
+    if isinstance(payload, Path):
+        return str(payload)
+    if is_dataclass(payload) and not isinstance(payload, type):
+        return _safe(asdict(payload))
+    if isinstance(payload, dict):
+        return {str(k): _safe(v) for k, v in payload.items()}
+    if isinstance(payload, (list, tuple)):
+        return [_safe(v) for v in payload]
+    return payload
+
+
+class Bridge:
+    def __init__(self) -> None:
+        self.orchestrator = MigrationOrchestrator()
+        self._worker: Optional[threading.Thread] = None
+        self._final_state: dict = {"status": "idle"}  # 'idle' | 'running' | 'done' | 'error'
+        self._lock = threading.Lock()
+
+    # ----------------------------- window helpers -----------------------------
+
+    def quit_app(self) -> None:
+        """Close the window. Deferred so the current JS-Python call can return
+        before WKWebView is torn down (otherwise the JS promise never resolves
+        and the window appears to crash/hang)."""
+        win = getattr(self, "_window", None)
+        if win is None:
+            return
+        threading.Timer(0.05, self._destroy_window_safely).start()
+
+    def _destroy_window_safely(self) -> None:
+        try:
+            self._window.destroy()
+        except Exception:
+            pass
+
+    # ---- backup management ------------------------------------------
+
+    def list_backups(self, profile_path: Optional[str] = None) -> list:
+        """List all *.backup.<unix_ts> files in a Zen profile, newest first."""
+        from datetime import datetime
+        profile = Path(profile_path) if profile_path else self._guess_zen_profile()
+        if profile is None or not profile.is_dir():
+            return []
+        items: list[dict] = []
+        for f in profile.glob("*.backup.*"):
+            try:
+                ts = int(f.name.rsplit(".backup.", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            original = f.name.split(".backup.")[0]
+            try:
+                size = f.stat().st_size
+            except OSError:
+                continue
+            items.append({
+                "path": str(f),
+                "name": f.name,
+                "original": original,
+                "ts": ts,
+                "size": size,
+                "iso": datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S"),
+            })
+        items.sort(key=lambda x: x["ts"], reverse=True)
+        return items
+
+    def restore_backup(self, backup_path: str) -> dict:
+        src = Path(backup_path)
+        if not src.is_file():
+            return {"ok": False, "error": "backup not found"}
+        try:
+            original = src.name.split(".backup.")[0]
+        except Exception:
+            return {"ok": False, "error": "could not derive original filename"}
+        target = src.parent / original
+        try:
+            import shutil as _shutil
+            # Snapshot the current target before overwriting (so the user can
+            # roll forward again if they restore the wrong backup).
+            if target.is_file():
+                ts = int(time.time())
+                _shutil.copy2(target, target.with_name(f"{original}.backup.{ts}"))
+            _shutil.copy2(src, target)
+            # Force WAL/SHM stale files to be discarded so SQLite re-reads cleanly.
+            for suffix in ("-wal", "-shm"):
+                stale = target.with_name(target.name + suffix)
+                if stale.is_file():
+                    try: stale.unlink()
+                    except Exception: pass
+            return {"ok": True, "restored": str(target)}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def delete_backup(self, backup_path: str) -> dict:
+        src = Path(backup_path)
+        if not src.is_file():
+            return {"ok": False, "error": "backup not found"}
+        try:
+            src.unlink()
+            return {"ok": True}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    def _guess_zen_profile(self) -> Optional[Path]:
+        from .env_check import list_zen_profiles
+        profs = list_zen_profiles()
+        return profs[0].path if profs else None
+
+    def open_path_in_finder(self, path: str) -> bool:
+        return open_in_finder(path)
+
+    def open_url(self, url: str) -> bool:
+        """Open an https:// URL in the user's default browser."""
+        if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+            return False
+        if sys.platform != "darwin":
+            return False
+        try:
+            import subprocess
+            subprocess.run(["open", url], capture_output=True, timeout=5)
+            return True
+        except Exception:
+            return False
+
+    def copy_to_clipboard(self, text: str) -> bool:
+        if sys.platform == "darwin":
+            try:
+                import subprocess
+                p = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+                p.communicate(input=text.encode("utf-8"), timeout=2)
+                return p.returncode == 0
+            except Exception:
+                return False
+        return False
+
+    # ---------- environment / preview / migration --------------
+
+    def check_env(self) -> dict:
+        try:
+            report = self.orchestrator.check_environment()
+            return _safe(env_report_to_dict(report))
+        except Exception as exc:
+            logger.exception("check_env failed")
+            return {"error": str(exc), "trace": traceback.format_exc()}
+
+    def quit_browser(self, name: str) -> dict:
+        if name not in ("arc", "zen"):
+            return {"ok": False, "error": "unknown browser"}
+        return _safe(quit_browser(name))  # type: ignore[arg-type]
+
+    def launch_zen(self) -> bool:
+        return launch_zen()
+
+    def preview(self, opts_json: str) -> dict:
+        try:
+            opts = self._parse_options(opts_json)
+            report = self.orchestrator.preview(opts)
+            return _safe(preview_to_dict(report))
+        except Exception as exc:
+            logger.exception("preview failed")
+            return {"error": str(exc), "trace": traceback.format_exc()}
+
+    def start_migration(self, opts_json: str) -> dict:
+        with self._lock:
+            if self._worker is not None and self._worker.is_alive():
+                return {"ok": False, "error": "migration already running"}
+
+        try:
+            opts = self._parse_options(opts_json)
+        except Exception as exc:
+            return {"ok": False, "error": f"bad options: {exc}"}
+
+        with self._lock:
+            self._final_state = {"status": "running"}
+
+        def _run() -> None:
+            try:
+                # Drain the iterator; events flow into the queue via the bus.
+                for _ in self.orchestrator.migrate(opts):
+                    pass
+                with self._lock:
+                    self._final_state = {
+                        "status": "done",
+                        "backups": [str(p) for p in self.orchestrator.find_backups(opts.zen_profile_path)],
+                        "zenProfilePath": str(opts.zen_profile_path),
+                    }
+            except Exception as exc:
+                logger.exception("migration worker crashed")
+                with self._lock:
+                    self._final_state = {
+                        "status": "error",
+                        "error": str(exc),
+                        "trace": traceback.format_exc(),
+                    }
+
+        self._worker = threading.Thread(target=_run, daemon=True, name="arc2zen-migrate")
+        self._worker.start()
+        return {"ok": True}
+
+    def drain_progress(self) -> dict:
+        events = self.orchestrator.bus.drain()
+        with self._lock:
+            state = dict(self._final_state)
+        return {"events": _safe(events), "state": state, "steps": list(GUI_STEPS), "labels": STEP_LABELS}
+
+    def get_step_metadata(self) -> dict:
+        return {"steps": list(GUI_STEPS), "labels": STEP_LABELS}
+
+    # ----------------------------- helpers -----------------------------------
+
+    def set_window(self, window: Any) -> None:
+        self._window = window
+
+    @staticmethod
+    def _parse_options(opts_json: str) -> MigrationOptions:
+        data = json.loads(opts_json) if isinstance(opts_json, str) else dict(opts_json)
+        zen_profile = Path(data["zenProfilePath"]).expanduser()
+        return MigrationOptions(
+            zen_profile_path=zen_profile,
+            arc_space_filter=data.get("arcSpaceFilter") or None,
+            folders_collapsed=bool(data.get("foldersCollapsed", True)),
+            include_workspaces=bool(data.get("includeWorkspaces", True)),
+            include_pinned_tabs=bool(data.get("includePinnedTabs", True)),
+            include_bookmarks=bool(data.get("includeBookmarks", True)),
+            include_favicons=bool(data.get("includeFavicons", True)),
+            include_open_tabs=bool(data.get("includeOpenTabs", False)),
+            include_history=bool(data.get("includeHistory", False)),
+            include_cookies=bool(data.get("includeCookies", False)),
+        )

--- a/app/bridge.py
+++ b/app/bridge.py
@@ -166,6 +166,14 @@ class Bridge:
             return "win"
         return "linux"
 
+    def version(self) -> str:
+        """Return the canonical app version string (e.g. ``"1.1.0"``)."""
+        try:
+            from .__version__ import VERSION
+            return VERSION
+        except Exception:
+            return "0.0.0"
+
     def copy_to_clipboard(self, text: str) -> bool:
         if not isinstance(text, str):
             return False

--- a/app/bridge.py
+++ b/app/bridge.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -148,27 +149,40 @@ class Bridge:
         return open_in_finder(path)
 
     def open_url(self, url: str) -> bool:
-        """Open an https:// URL in the user's default browser."""
+        """Open an http(s) URL in the user's default browser, cross-platform."""
         if not isinstance(url, str) or not url.startswith(("http://", "https://")):
             return False
-        if sys.platform != "darwin":
-            return False
         try:
-            import subprocess
-            subprocess.run(["open", url], capture_output=True, timeout=5)
-            return True
+            import webbrowser
+            return webbrowser.open(url, new=2)
         except Exception:
             return False
 
-    def copy_to_clipboard(self, text: str) -> bool:
+    def platform(self) -> str:
+        """Return ``"mac"``, ``"win"``, or ``"linux"`` for the JS side to gate UI."""
         if sys.platform == "darwin":
-            try:
-                import subprocess
+            return "mac"
+        if os.name == "nt":
+            return "win"
+        return "linux"
+
+    def copy_to_clipboard(self, text: str) -> bool:
+        if not isinstance(text, str):
+            return False
+        try:
+            import subprocess
+            if sys.platform == "darwin":
                 p = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
                 p.communicate(input=text.encode("utf-8"), timeout=2)
                 return p.returncode == 0
-            except Exception:
-                return False
+            if os.name == "nt":
+                # clip.exe ships with every Windows install. It expects
+                # UTF-16 LE on stdin; pass without a BOM.
+                p = subprocess.Popen(["clip.exe"], stdin=subprocess.PIPE)
+                p.communicate(input=text.encode("utf-16-le"), timeout=2)
+                return p.returncode == 0
+        except Exception:
+            return False
         return False
 
     # ---------- environment / preview / migration --------------

--- a/app/browser_control.py
+++ b/app/browser_control.py
@@ -1,26 +1,35 @@
 """
-Browser control via AppleScript / `open`.
+Browser control: graceful quit, launch Zen, reveal-in-shell.
 
-Used for two GUI affordances:
-- Quitting Arc / Zen gracefully when the Detect screen finds them running.
-- Launching Zen from the Done screen so the user can see the result immediately.
+Cross-platform:
+- macOS: ``osascript -e 'tell application "X" to quit'`` + ``open -a`` + ``open -R``.
+- Windows: ``taskkill /im X.exe`` (graceful WM_CLOSE, falls back to /f) +
+  ``Popen([zen.exe])`` from the path that ``env_check`` discovered, +
+  ``explorer /select,<path>``.
 
-AppleScript `tell application "X" to quit` requests a clean shutdown, which
-gives the browser a chance to save its session. We poll for up to ``timeout``
-seconds and report what actually quit.
+Each ``quit_browser`` call polls for up to ``timeout`` seconds and reports
+what actually exited.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Optional
 
-from .env_check import is_arc_running, is_zen_running
+from .env_check import (
+    is_arc_running,
+    is_zen_running,
+    list_zen_profiles,
+)
 
 BrowserName = Literal["arc", "zen"]
 
+
+# ---------- macOS-specific helpers ----------
 
 _APPLESCRIPT_QUIT = {
     "arc": 'tell application "Arc" to quit',
@@ -29,8 +38,6 @@ _APPLESCRIPT_QUIT = {
 
 
 def _run_osascript(script: str, timeout: float = 5.0) -> bool:
-    if sys.platform != "darwin":
-        return False
     try:
         r = subprocess.run(
             ["osascript", "-e", script],
@@ -41,32 +48,107 @@ def _run_osascript(script: str, timeout: float = 5.0) -> bool:
         return False
 
 
+# ---------- Windows-specific helpers ----------
+
+# Process names per browser. We taskkill all matches in case the user has
+# the older standalone-installer Arc (just "Arc.exe") alongside the UWP one.
+_WINDOWS_PROCESS_NAMES = {
+    "arc": ("Arc.exe",),
+    "zen": ("zen.exe", "zen-bin.exe"),
+}
+
+
+def _taskkill(image_name: str, force: bool) -> bool:
+    flags = ["/im", image_name]
+    if force:
+        flags.append("/f")
+    try:
+        r = subprocess.run(
+            ["taskkill", *flags],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return False
+    # taskkill returns 0 if at least one process was signalled, 128 if no
+    # process matched. Treat both as "did our best".
+    return r.returncode in (0, 128)
+
+
+def _windows_zen_exe() -> Optional[Path]:
+    """Find ``zen.exe`` (or ``zen-bin.exe``) under the active Zen profile.
+
+    Zen on Windows installs alongside the user profile; the profile's
+    parent dir contains the executable. Falls back to common install
+    locations.
+    """
+    home = Path.home()
+    candidates: list[Path] = []
+    profiles = list_zen_profiles()
+    for prof in profiles:
+        # profile is at <root>/Profiles/<id>.<name>/; walk up two levels
+        # and check siblings.
+        root = prof.path.parent.parent
+        for name in ("zen.exe", "zen-bin.exe"):
+            candidates.append(root / name)
+    candidates += [
+        home / "AppData/Local/zen/zen.exe",
+        Path("C:/Program Files/Zen Browser/zen.exe"),
+        Path("C:/Program Files (x86)/Zen Browser/zen.exe"),
+    ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+# ---------- public API ----------
+
+
 def quit_browser(name: BrowserName, timeout: float = 6.0) -> dict:
-    """Ask AppleScript to quit a browser, then poll until it actually exits.
+    """Ask the OS to quit a browser, then poll until it actually exits.
 
     Returns ``{"ok": bool, "running": bool, "elapsed": float}``.
     """
-    if sys.platform != "darwin":
-        return {"ok": False, "running": _is_running(name), "elapsed": 0.0,
-                "error": "AppleScript quit only works on macOS"}
-
-    script = _APPLESCRIPT_QUIT.get(name)
-    if script is None:
+    if name not in ("arc", "zen"):
         return {"ok": False, "running": _is_running(name), "elapsed": 0.0,
                 "error": f"unknown browser: {name}"}
 
     started = time.time()
-    sent = _run_osascript(script, timeout=2.0)
-    if not sent:
-        return {"ok": False, "running": _is_running(name),
-                "elapsed": time.time() - started,
-                "error": "osascript failed (is the browser actually open?)"}
+
+    if sys.platform == "darwin":
+        script = _APPLESCRIPT_QUIT[name]
+        sent = _run_osascript(script, timeout=2.0)
+        if not sent:
+            return {"ok": False, "running": _is_running(name),
+                    "elapsed": time.time() - started,
+                    "error": "osascript failed (is the browser actually open?)"}
+    elif os.name == "nt":
+        any_signalled = False
+        for image in _WINDOWS_PROCESS_NAMES[name]:
+            if _taskkill(image, force=False):
+                any_signalled = True
+        if not any_signalled:
+            return {"ok": False, "running": _is_running(name),
+                    "elapsed": time.time() - started,
+                    "error": "taskkill could not signal the browser"}
+    else:
+        return {"ok": False, "running": _is_running(name), "elapsed": 0.0,
+                "error": "graceful quit only supports macOS and Windows"}
 
     deadline = started + timeout
     while time.time() < deadline:
         if not _is_running(name):
             return {"ok": True, "running": False, "elapsed": time.time() - started}
         time.sleep(0.25)
+
+    # Soft quit timed out. On Windows, escalate to /f and report what happens.
+    if os.name == "nt":
+        for image in _WINDOWS_PROCESS_NAMES[name]:
+            _taskkill(image, force=True)
+        time.sleep(0.5)
+        if not _is_running(name):
+            return {"ok": True, "running": False, "elapsed": time.time() - started,
+                    "forced": True}
 
     return {"ok": False, "running": True, "elapsed": time.time() - started,
             "error": "browser did not quit within timeout"}
@@ -77,25 +159,49 @@ def _is_running(name: BrowserName) -> bool:
 
 
 def launch_zen() -> bool:
-    """Open Zen via macOS `open -a`. No-op on non-macOS."""
-    if sys.platform != "darwin":
+    """Open Zen using the OS shell. Returns True on success."""
+    if sys.platform == "darwin":
+        for app_name in ("Zen", "Zen Browser", "zen"):
+            try:
+                r = subprocess.run(["open", "-a", app_name],
+                                   capture_output=True, text=True, timeout=5)
+            except Exception:
+                continue
+            if r.returncode == 0:
+                return True
         return False
-    for app_name in ("Zen", "Zen Browser", "zen"):
+
+    if os.name == "nt":
+        exe = _windows_zen_exe()
+        if exe is None:
+            return False
         try:
-            r = subprocess.run(["open", "-a", app_name], capture_output=True, text=True, timeout=5)
-        except Exception:
-            continue
-        if r.returncode == 0:
+            subprocess.Popen([str(exe)],
+                             creationflags=getattr(subprocess, "DETACHED_PROCESS", 0))
             return True
+        except Exception:
+            return False
+
     return False
 
 
 def open_in_finder(path: str) -> bool:
-    """Reveal a file or folder in Finder."""
-    if sys.platform != "darwin":
-        return False
-    try:
-        r = subprocess.run(["open", "-R", path], capture_output=True, text=True, timeout=5)
-    except Exception:
-        return False
-    return r.returncode == 0
+    """Reveal a file or folder in the OS file manager."""
+    if sys.platform == "darwin":
+        try:
+            r = subprocess.run(["open", "-R", path],
+                               capture_output=True, text=True, timeout=5)
+        except Exception:
+            return False
+        return r.returncode == 0
+
+    if os.name == "nt":
+        try:
+            # `explorer /select,<path>` opens the parent folder with the
+            # file selected. Note the comma syntax is intentional.
+            subprocess.Popen(["explorer", f"/select,{path}"])
+            return True
+        except Exception:
+            return False
+
+    return False

--- a/app/browser_control.py
+++ b/app/browser_control.py
@@ -1,0 +1,101 @@
+"""
+Browser control via AppleScript / `open`.
+
+Used for two GUI affordances:
+- Quitting Arc / Zen gracefully when the Detect screen finds them running.
+- Launching Zen from the Done screen so the user can see the result immediately.
+
+AppleScript `tell application "X" to quit` requests a clean shutdown, which
+gives the browser a chance to save its session. We poll for up to ``timeout``
+seconds and report what actually quit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from typing import Literal
+
+from .env_check import is_arc_running, is_zen_running
+
+BrowserName = Literal["arc", "zen"]
+
+
+_APPLESCRIPT_QUIT = {
+    "arc": 'tell application "Arc" to quit',
+    "zen": 'tell application "Zen" to quit',
+}
+
+
+def _run_osascript(script: str, timeout: float = 5.0) -> bool:
+    if sys.platform != "darwin":
+        return False
+    try:
+        r = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def quit_browser(name: BrowserName, timeout: float = 6.0) -> dict:
+    """Ask AppleScript to quit a browser, then poll until it actually exits.
+
+    Returns ``{"ok": bool, "running": bool, "elapsed": float}``.
+    """
+    if sys.platform != "darwin":
+        return {"ok": False, "running": _is_running(name), "elapsed": 0.0,
+                "error": "AppleScript quit only works on macOS"}
+
+    script = _APPLESCRIPT_QUIT.get(name)
+    if script is None:
+        return {"ok": False, "running": _is_running(name), "elapsed": 0.0,
+                "error": f"unknown browser: {name}"}
+
+    started = time.time()
+    sent = _run_osascript(script, timeout=2.0)
+    if not sent:
+        return {"ok": False, "running": _is_running(name),
+                "elapsed": time.time() - started,
+                "error": "osascript failed (is the browser actually open?)"}
+
+    deadline = started + timeout
+    while time.time() < deadline:
+        if not _is_running(name):
+            return {"ok": True, "running": False, "elapsed": time.time() - started}
+        time.sleep(0.25)
+
+    return {"ok": False, "running": True, "elapsed": time.time() - started,
+            "error": "browser did not quit within timeout"}
+
+
+def _is_running(name: BrowserName) -> bool:
+    return is_arc_running() if name == "arc" else is_zen_running()
+
+
+def launch_zen() -> bool:
+    """Open Zen via macOS `open -a`. No-op on non-macOS."""
+    if sys.platform != "darwin":
+        return False
+    for app_name in ("Zen", "Zen Browser", "zen"):
+        try:
+            r = subprocess.run(["open", "-a", app_name], capture_output=True, text=True, timeout=5)
+        except Exception:
+            continue
+        if r.returncode == 0:
+            return True
+    return False
+
+
+def open_in_finder(path: str) -> bool:
+    """Reveal a file or folder in Finder."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        r = subprocess.run(["open", "-R", path], capture_output=True, text=True, timeout=5)
+    except Exception:
+        return False
+    return r.returncode == 0

--- a/app/env_check.py
+++ b/app/env_check.py
@@ -46,17 +46,31 @@ class EnvReport:
 # ---------- Arc ----------
 
 
-def _arc_user_data_dir() -> Path:
+def _arc_user_data_dirs() -> list[Path]:
+    """Return every plausible Arc User Data root for the current OS.
+
+    Windows users may have either the UWP package or the standalone-installer
+    layout, occasionally both. macOS only uses one canonical location.
+    """
     home = Path.home()
     if sys.platform == "darwin":
-        return home / "Library/Application Support/Arc/User Data"
+        return [home / "Library/Application Support/Arc/User Data"]
     if os.name == "nt":
-        return (
-            home
-            / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
-            / "LocalCache/Local/Arc/User Data"
-        )
-    return home / ".config/Arc/User Data"
+        return [
+            home / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+                 / "LocalCache/Local/Arc/User Data",
+            home / "AppData/Local/Arc/User Data",
+        ]
+    return [home / ".config/Arc/User Data"]
+
+
+def _arc_user_data_dir() -> Optional[Path]:
+    """First existing Arc User Data dir, or the canonical-but-missing one."""
+    candidates = _arc_user_data_dirs()
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return candidates[0] if candidates else None
 
 
 def _arc_storable_sidebar() -> Optional[Path]:
@@ -66,6 +80,7 @@ def _arc_storable_sidebar() -> Optional[Path]:
         home / "Library/Application Support/Arc/StorableSidebar.json",
         home / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
              / "LocalCache/Local/Arc/StorableSidebar.json",
+        home / "AppData/Local/Arc/StorableSidebar.json",
     ]
     for c in candidates:
         if c.is_file():
@@ -73,15 +88,19 @@ def _arc_storable_sidebar() -> Optional[Path]:
     return None
 
 
-def _arc_profiles(user_data: Path) -> list[str]:
-    if not user_data.is_dir():
+def _arc_profiles(user_data: Optional[Path]) -> list[str]:
+    """List Arc profile directory names. Newer Chromium builds keep the
+    History SQLite at ``<profile>/History``; some store it under
+    ``<profile>/Network/`` after the cookie/network split. Either is a
+    sufficient sign of a real profile.
+    """
+    if user_data is None or not user_data.is_dir():
         return []
     out: list[str] = []
     for entry in sorted(user_data.iterdir()):
         if not entry.is_dir():
             continue
-        # Arc's per-profile dirs always contain a History SQLite file
-        if (entry / "History").is_file():
+        if (entry / "History").is_file() or (entry / "Network" / "Cookies").is_file():
             out.append(entry.name)
     return out
 
@@ -145,7 +164,27 @@ def _pgrep_any(paths: tuple[str, ...]) -> bool:
     return False
 
 
+def _tasklist_running(image_names: tuple[str, ...]) -> bool:
+    """Windows: faster running-process check via ``tasklist`` (~50 ms cold)
+    rather than ``Get-Process`` via PowerShell (~300 ms cold).
+    """
+    for name in image_names:
+        try:
+            r = subprocess.run(
+                ["tasklist", "/fi", f"imagename eq {name}", "/fo", "csv", "/nh"],
+                capture_output=True, text=True, timeout=4,
+            )
+        except Exception:
+            continue
+        # ``tasklist`` prints a notice line ("INFO: No tasks ...") on stdout
+        # when nothing matches; success means at least one CSV row.
+        if r.returncode == 0 and r.stdout and name.lower() in r.stdout.lower():
+            return True
+    return False
+
+
 def _powershell_running(name: str) -> bool:
+    """Slower PowerShell-based fallback, kept for parity."""
     try:
         r = subprocess.run(
             ["powershell", "-NoProfile", "-Command",
@@ -157,11 +196,15 @@ def _powershell_running(name: str) -> bool:
     return r.returncode == 0 and (r.stdout or "0").strip() != "0"
 
 
+_ARC_WINDOWS_IMAGES = ("Arc.exe",)
+_ZEN_WINDOWS_IMAGES = ("zen.exe", "zen-bin.exe")
+
+
 def is_arc_running() -> bool:
     if sys.platform == "darwin" or sys.platform == "linux":
         return _pgrep_any(_ARC_PROCESS_PATHS)
     if os.name == "nt":
-        return _powershell_running("Arc")
+        return _tasklist_running(_ARC_WINDOWS_IMAGES)
     return False
 
 
@@ -169,7 +212,7 @@ def is_zen_running() -> bool:
     if sys.platform == "darwin" or sys.platform == "linux":
         return _pgrep_any(_ZEN_PROCESS_PATHS)
     if os.name == "nt":
-        return _powershell_running("zen") or _powershell_running("Zen")
+        return _tasklist_running(_ZEN_WINDOWS_IMAGES)
     return False
 
 

--- a/app/env_check.py
+++ b/app/env_check.py
@@ -1,0 +1,251 @@
+"""
+Environment detection for the Detect screen.
+
+We deliberately do NOT import ``src.arc_profile_discovery`` because that file
+contains a syntax error (mixed tabs/spaces) in the current upstream tree.
+Instead we glob the well-known Arc and Zen paths directly. The logic mirrors
+the working subset that the CLI tool already relies on via
+``arc_pinned_tab_extractor`` (which reads ``StorableSidebar.json`` directly).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ZenProfile:
+    name: str
+    path: Path
+    is_release: bool          # cheap heuristic: name contains "release"
+    has_zen_sessions: bool    # zen-sessions.jsonlz4 exists (modern format)
+
+
+@dataclass(frozen=True)
+class EnvReport:
+    arc_installed: bool
+    arc_data_path: Optional[Path]
+    arc_storable_sidebar: Optional[Path]
+    arc_profiles: list[str]            # subdirectories under "User Data"
+    arc_running: bool
+    zen_installed: bool
+    zen_profiles: list[ZenProfile]
+    zen_running: bool
+    has_lz4: bool
+    has_cryptography: bool
+    previous_migration_detected: bool
+    errors: list[str] = field(default_factory=list)
+
+
+# ---------- Arc ----------
+
+
+def _arc_user_data_dir() -> Path:
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library/Application Support/Arc/User Data"
+    if os.name == "nt":
+        return (
+            home
+            / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+            / "LocalCache/Local/Arc/User Data"
+        )
+    return home / ".config/Arc/User Data"
+
+
+def _arc_storable_sidebar() -> Optional[Path]:
+    """Path to Arc's StorableSidebar.json: present whenever Arc has data."""
+    home = Path.home()
+    candidates = [
+        home / "Library/Application Support/Arc/StorableSidebar.json",
+        home / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+             / "LocalCache/Local/Arc/StorableSidebar.json",
+    ]
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def _arc_profiles(user_data: Path) -> list[str]:
+    if not user_data.is_dir():
+        return []
+    out: list[str] = []
+    for entry in sorted(user_data.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Arc's per-profile dirs always contain a History SQLite file
+        if (entry / "History").is_file():
+            out.append(entry.name)
+    return out
+
+
+# ---------- Zen ----------
+
+
+def _zen_profiles_root() -> Path:
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library/Application Support/zen/Profiles"
+    if os.name == "nt":
+        return home / "AppData/Roaming/zen/Profiles"
+    return home / ".zen"
+
+
+def list_zen_profiles() -> list[ZenProfile]:
+    root = _zen_profiles_root()
+    if not root.is_dir():
+        return []
+    result: list[ZenProfile] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        # Heuristic: a real profile has at least places.sqlite
+        if not (entry / "places.sqlite").is_file():
+            continue
+        name = entry.name.split(".", 1)[1] if "." in entry.name else entry.name
+        result.append(
+            ZenProfile(
+                name=name,
+                path=entry,
+                is_release="release" in entry.name.lower(),
+                has_zen_sessions=(entry / "zen-sessions.jsonlz4").is_file(),
+            )
+        )
+    # Prefer release-labelled profiles first
+    result.sort(key=lambda p: (not p.is_release, p.name.lower()))
+    return result
+
+
+# ---------- browsers running ----------
+
+
+_ARC_PROCESS_PATHS = ("/Applications/Arc.app",)
+_ZEN_PROCESS_PATHS = (
+    "/Applications/Zen.app/Contents/MacOS/zen",
+    "/Applications/Zen Browser.app/Contents/MacOS/zen",
+    "/Applications/zen.app/Contents/MacOS/zen",
+)
+
+
+def _pgrep_any(paths: tuple[str, ...]) -> bool:
+    for p in paths:
+        try:
+            r = subprocess.run(["pgrep", "-f", p], capture_output=True, text=True, timeout=2)
+        except Exception:
+            continue
+        if r.returncode == 0 and r.stdout.strip():
+            return True
+    return False
+
+
+def _powershell_running(name: str) -> bool:
+    try:
+        r = subprocess.run(
+            ["powershell", "-NoProfile", "-Command",
+             f'(Get-Process -Name "{name}" -ErrorAction SilentlyContinue).Count'],
+            capture_output=True, text=True, timeout=4,
+        )
+    except Exception:
+        return False
+    return r.returncode == 0 and (r.stdout or "0").strip() != "0"
+
+
+def is_arc_running() -> bool:
+    if sys.platform == "darwin" or sys.platform == "linux":
+        return _pgrep_any(_ARC_PROCESS_PATHS)
+    if os.name == "nt":
+        return _powershell_running("Arc")
+    return False
+
+
+def is_zen_running() -> bool:
+    if sys.platform == "darwin" or sys.platform == "linux":
+        return _pgrep_any(_ZEN_PROCESS_PATHS)
+    if os.name == "nt":
+        return _powershell_running("zen") or _powershell_running("Zen")
+    return False
+
+
+# ---------- previous migration marker ----------
+
+
+def _previous_migration_detected(zen_profile_path: Optional[Path]) -> bool:
+    if zen_profile_path is None:
+        return False
+    return (zen_profile_path / ".arc2zen-migrated").is_file()
+
+
+# ---------- module checks ----------
+
+
+def _has_module(name: str) -> bool:
+    try:
+        __import__(name)
+        return True
+    except Exception:
+        return False
+
+
+# ---------- public ----------
+
+
+def check_environment() -> EnvReport:
+    errors: list[str] = []
+
+    arc_user_data = _arc_user_data_dir()
+    arc_sidebar = _arc_storable_sidebar()
+    arc_installed = arc_sidebar is not None
+    arc_profile_names = _arc_profiles(arc_user_data) if arc_installed else []
+
+    zen_profiles = list_zen_profiles()
+    zen_installed = bool(zen_profiles)
+
+    return EnvReport(
+        arc_installed=arc_installed,
+        arc_data_path=arc_user_data if arc_installed else None,
+        arc_storable_sidebar=arc_sidebar,
+        arc_profiles=arc_profile_names,
+        arc_running=is_arc_running(),
+        zen_installed=zen_installed,
+        zen_profiles=zen_profiles,
+        zen_running=is_zen_running(),
+        has_lz4=_has_module("lz4"),
+        has_cryptography=_has_module("cryptography"),
+        previous_migration_detected=_previous_migration_detected(
+            zen_profiles[0].path if zen_profiles else None
+        ),
+        errors=errors,
+    )
+
+
+def env_report_to_dict(report: EnvReport) -> dict:
+    """JSON-serializable shape for the JS bridge."""
+    return {
+        "arcInstalled": report.arc_installed,
+        "arcDataPath": str(report.arc_data_path) if report.arc_data_path else None,
+        "arcStorableSidebar": str(report.arc_storable_sidebar) if report.arc_storable_sidebar else None,
+        "arcProfiles": list(report.arc_profiles),
+        "arcRunning": report.arc_running,
+        "zenInstalled": report.zen_installed,
+        "zenProfiles": [
+            {
+                "name": p.name,
+                "path": str(p.path),
+                "isRelease": p.is_release,
+                "hasZenSessions": p.has_zen_sessions,
+            }
+            for p in report.zen_profiles
+        ],
+        "zenRunning": report.zen_running,
+        "hasLz4": report.has_lz4,
+        "hasCryptography": report.has_cryptography,
+        "previousMigrationDetected": report.previous_migration_detected,
+        "errors": list(report.errors),
+    }

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -886,12 +886,23 @@ function shortenPath(p) {
 
 // ---- bootstrap ------------------------------------------------------------
 
+async function setPlatformAttribute() {
+  const api = Bridge();
+  if (!api) return;
+  try {
+    const p = await api.platform();
+    if (typeof p === "string") document.body.dataset.platform = p;
+  } catch (_) { /* best effort */ }
+}
+
 window.addEventListener("pywebviewready", () => {
+  setPlatformAttribute();
   decorateBranding();
   setScreen("welcome");
 });
 setTimeout(() => {
   if (!Bridge()) return;
+  setPlatformAttribute();
   decorateBranding();
   setScreen("welcome");
 }, 200);

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -1,0 +1,897 @@
+/* Arc2Zen frontend: vanilla JS state machine.
+ *
+ * All dynamic content is built with createElement / textContent. We never
+ * assign user-derived strings (or strings that could embed user data) to
+ * innerHTML; the only innerHTML use clears nodes via empty string.
+ */
+
+const $  = (id) => document.getElementById(id);
+const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+const Bridge = () => (window.pywebview && window.pywebview.api) || null;
+const sleep  = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function el(tag, props, children) {
+  const e = document.createElement(tag);
+  if (props) {
+    for (const [k, v] of Object.entries(props)) {
+      if (v == null) continue;
+      if (k === "class") e.className = v;
+      else if (k === "dataset") Object.assign(e.dataset, v);
+      else if (k.startsWith("on") && typeof v === "function") e.addEventListener(k.slice(2).toLowerCase(), v);
+      else if (k === "text") e.textContent = String(v);
+      else if (k === "value") e.value = v;
+      else if (k === "selected") e.selected = !!v;
+      else e.setAttribute(k, String(v));
+    }
+  }
+  for (const c of (children || [])) {
+    if (c == null || c === false) continue;
+    e.appendChild(typeof c === "string" ? document.createTextNode(c) : c);
+  }
+  return e;
+}
+
+function clear(node) { while (node.firstChild) node.removeChild(node.firstChild); }
+function replace(node, ...kids) { clear(node); for (const k of kids) if (k) node.appendChild(k); }
+
+async function whenBridgeReady(timeoutMs = 5000) {
+  const started = Date.now();
+  while (!Bridge()) {
+    if (Date.now() - started > timeoutMs) throw new Error("Bridge not ready");
+    await sleep(50);
+  }
+  return Bridge();
+}
+
+function setScreen(name) {
+  document.body.dataset.screen = name;
+  for (const node of $$(".screen")) {
+    node.classList.toggle("is-active", node.id === `screen-${name}`);
+  }
+}
+
+// ---- state ----------------------------------------------------------------
+
+const state = {
+  env: null,
+  selectedZenProfile: null,
+  preview: null,
+  options: {
+    foldersCollapsed: true,
+    includeWorkspaces: true,
+    includePinnedTabs: true,
+    includeBookmarks: true,
+    includeFavicons: true,
+    includeOpenTabs: false,
+    includeHistory: false,
+    includeCookies: false,
+  },
+  steps: [],
+  stepLabels: {},
+  stepStates: {},
+  stepSummaries: {},
+  logLines: [],
+  pollHandle: null,
+  startedAt: 0,
+  elapsedHandle: null,
+  activeStep: null,
+  activeDetail: "",
+  activeProgress: null,  // 0..1 or null
+};
+
+// ---- button loading state helper ----------------------------------------
+
+function setLoading(btn, on, label = null) {
+  if (on) {
+    if (label && !btn.dataset.savedLabel) {
+      btn.dataset.savedLabel = btn.textContent;
+      btn.textContent = label;
+    }
+    if (!btn.querySelector(".spinner")) {
+      btn.insertBefore(el("span", {class: "spinner"}), btn.firstChild);
+    }
+    btn.classList.add("is-loading");
+  } else {
+    btn.classList.remove("is-loading");
+    const sp = btn.querySelector(".spinner"); if (sp) sp.remove();
+    if (btn.dataset.savedLabel) {
+      btn.textContent = btn.dataset.savedLabel;
+      delete btn.dataset.savedLabel;
+    }
+  }
+}
+
+// ---- brand marks (Arc / Zen) --------------------------------------------
+//
+// Inline SVG glyphs rendered over a CSS-gradient badge.
+// Sizes: default 56px (welcome hero), small 28px (cards).
+
+// Arc Browser logo paths (CC-licensed source: Wikimedia Commons,
+// File:Arc_(browser)_logo.svg). Native viewBox "0 0 82 68"; we add a
+// small padding so the mark sits with breathing room inside the badge.
+const ARC_PATHS = [
+  ["#1a007f", "m28.8 51.97 6.35-13.36c-4.85-1.03-9.73-4.03-12.49-7.68l-6.64 13.96c3.69 3.13 8.12 5.59 12.78 7.08"],
+  ["#4e000a", "M55.3 30.53c-3.19 3.91-7.62 6.81-12.36 7.94l6.33 13.32c4.62-1.56 8.94-4.08 12.67-7.31L55.3 30.53z"],
+  ["#1a007f", "m16.02 44.89-3.32 6.98c-1.69 3.55-.42 7.92 3.06 9.77 3.69 1.96 8.23.43 10.01-3.3l3.03-6.37a37.885 37.885 0 0 1-12.78-7.08"],
+  ["#ff9396", "M68.48 15.29a7.29 7.29 0 0 0-8.58 5.72c-.7 3.5-2.34 6.76-4.6 9.53l6.63 13.96c6.12-5.31 10.64-12.54 12.26-20.63.79-3.96-1.77-7.8-5.71-8.58"],
+  ["#002dc8", "M42.94 38.47c-1.42.34-2.87.52-4.32.52-1.13 0-2.3-.13-3.47-.38-4.85-1.03-9.73-4.03-12.49-7.68-.69-.91-1.25-1.86-1.64-2.83-1.51-3.73-5.76-5.53-9.49-4.03C7.8 25.58 6 29.83 7.5 33.56c1.71 4.24 4.73 8.13 8.52 11.33a37.84 37.84 0 0 0 12.77 7.08c3.21 1.03 6.54 1.6 9.82 1.6 3.64 0 7.23-.63 10.65-1.78l-6.32-13.32z"],
+  ["#ff536a", "m65.43 51.84-3.5-7.36-6.63-13.95-.01.01s0-.01.01-.01l-9.64-20.28a7.292 7.292 0 0 0-6.58-4.16c-2.81 0-5.37 1.62-6.58 4.16l-9.83 20.68c2.76 3.65 7.64 6.65 12.49 7.68l3.18-6.68c.3-.63 1.2-.63 1.5 0l3.11 6.54h.02-.02l6.33 13.32 3.11 6.54a7.28 7.28 0 0 0 6.59 4.16c.65 0 1.3-.09 1.94-.27 4.39-1.21 6.47-6.26 4.51-10.38"],
+];
+
+function makeArcMark(size = "default") {
+  const wrap = document.createElement("span");
+  wrap.className = `brand-mark arc${size === "small" ? " small" : ""}${size === "tiny" ? " tiny" : ""}`;
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "-6 -7 94 82");
+  svg.setAttribute("fill", "none");
+  for (const [fill, d] of ARC_PATHS) {
+    svgChild(svg, "path", {d, fill, "fill-rule": "evenodd", "clip-rule": "evenodd"});
+  }
+  wrap.appendChild(svg);
+  return wrap;
+}
+
+function makeZenMark(size = "default") {
+  const wrap = document.createElement("span");
+  wrap.className = `brand-mark zen${size === "small" ? " small" : ""}${size === "tiny" ? " tiny" : ""}`;
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 32 32");
+  svg.setAttribute("fill", "none");
+  // Three hollow concentric rings, thin white stroke, empty centre.
+  const cx = 16, cy = 16;
+  for (const r of [12, 8, 4]) {
+    svgChild(svg, "circle", {cx, cy, r,
+      stroke: "currentColor", "stroke-width": 1.3, fill: "none"});
+  }
+  wrap.appendChild(svg);
+  return wrap;
+}
+
+function makeArrowGlyph() {
+  const span = document.createElement("span");
+  span.className = "arrow";
+  span.textContent = "→";
+  return span;
+}
+
+// Decorate static placeholders on welcome + detect.
+function decorateBranding() {
+  const pair = $("brand-pair");
+  if (pair && !pair.firstChild) {
+    pair.appendChild(makeArcMark());
+    pair.appendChild(makeArrowGlyph());
+    pair.appendChild(makeZenMark());
+  }
+  const arcMark = $("arc-mark");
+  if (arcMark) {
+    const fresh = makeArcMark("small");
+    fresh.id = "arc-mark";
+    arcMark.replaceWith(fresh);
+  }
+  const zenMark = $("zen-mark");
+  if (zenMark) {
+    const fresh = makeZenMark("small");
+    fresh.id = "zen-mark";
+    zenMark.replaceWith(fresh);
+  }
+}
+
+// ---- titlebar -------------------------------------------------------------
+
+$("tl-close").addEventListener("click", async () => {
+  const api = Bridge(); if (api) api.quit_app();
+});
+
+// ---- welcome --------------------------------------------------------------
+
+$("welcome-go").addEventListener("click", () => goToDetect());
+
+async function goToDetect() {
+  setScreen("detect");
+  await runDetect();
+}
+
+// ---- detect ---------------------------------------------------------------
+
+async function runDetect() {
+  const api = await whenBridgeReady();
+  $("arc-pill").textContent = "Detecting…";
+  $("zen-pill").textContent = "Detecting…";
+  state.env = await api.check_env();
+  renderDetect(state.env);
+}
+
+function renderDetect(env) {
+  // Arc card
+  const arcOk = env.arcInstalled && !env.arcRunning && env.arcProfiles.length > 0;
+  const arcPill = $("arc-pill");
+  const arcDetail = $("arc-detail");
+  const arcCard = $("card-arc");
+  $("arc-running-row").style.display = env.arcRunning ? "" : "none";
+
+  arcCard.dataset.ok = arcOk ? "true" : "false";
+  if (!env.arcInstalled) {
+    arcPill.className = "pill pill-err"; arcPill.textContent = "Not found";
+    arcDetail.textContent = "We couldn't find Arc data in ~/Library/Application Support/Arc.";
+  } else if (env.arcRunning) {
+    arcPill.className = "pill pill-warn"; arcPill.textContent = "Running";
+    arcDetail.textContent = "Arc is open. Quit it before we read its data.";
+  } else if (env.arcProfiles.length === 0) {
+    arcPill.className = "pill pill-warn"; arcPill.textContent = "Empty";
+    arcDetail.textContent = "Arc is installed but no profiles were found.";
+  } else {
+    arcPill.className = "pill pill-ok"; arcPill.textContent = "Ready";
+    const n = env.arcProfiles.length;
+    arcDetail.textContent = `${n} profile${n === 1 ? "" : "s"}: ${env.arcProfiles.join(", ")}.`;
+  }
+
+  // Zen card
+  const zenCard = $("card-zen");
+  const zenPill = $("zen-pill");
+  const zenDetail = $("zen-detail");
+  const zenSelect = $("zen-profile-select");
+  $("zen-running-row").style.display = env.zenRunning ? "" : "none";
+  $("zen-install-row").style.display = env.zenInstalled ? "none" : "";
+
+  if (!env.zenInstalled) {
+    zenCard.dataset.ok = "false";
+    zenPill.className = "pill pill-err"; zenPill.textContent = "Not installed";
+    zenDetail.textContent = "Zen Browser doesn't appear to be installed yet.";
+    zenSelect.style.display = "none";
+  } else if (env.zenRunning) {
+    zenCard.dataset.ok = "false";
+    zenPill.className = "pill pill-warn"; zenPill.textContent = "Running";
+    zenDetail.textContent = "Zen is open. Quit it before we write to its profile.";
+    zenSelect.style.display = "none";
+  } else {
+    zenCard.dataset.ok = "true";
+    zenPill.className = "pill pill-ok"; zenPill.textContent = "Ready";
+    if (env.zenProfiles.length > 1) {
+      zenDetail.textContent = `${env.zenProfiles.length} profiles found. Pick one:`;
+      zenSelect.style.display = "";
+      clear(zenSelect);
+      env.zenProfiles.forEach((p, i) => {
+        zenSelect.appendChild(el("option", {value: p.path, selected: i === 0,
+          text: p.name + (p.isRelease ? " (release)" : "")}));
+      });
+      state.selectedZenProfile = env.zenProfiles[0].path;
+      zenSelect.onchange = () => { state.selectedZenProfile = zenSelect.value; updateGate(state.env); };
+    } else {
+      const p = env.zenProfiles[0];
+      zenDetail.textContent = `Profile: ${p.name}.`;
+      zenSelect.style.display = "none";
+      state.selectedZenProfile = p.path;
+    }
+  }
+
+  updateGate(env);
+}
+
+function updateGate(env) {
+  const gate = $("detect-gate");
+  const text = $("detect-gate-text");
+  const next = $("detect-next");
+
+  const issues = [];
+  if (!env.arcInstalled) issues.push("Arc isn't installed.");
+  if (env.arcRunning) issues.push("Arc is still running.");
+  if (env.arcInstalled && env.arcProfiles.length === 0) issues.push("Arc has no profiles.");
+  if (!env.zenInstalled) issues.push("Zen isn't installed (or never launched).");
+  if (env.zenRunning) issues.push("Zen is still running.");
+  if (!env.hasLz4) issues.push("Python lz4 module missing (build issue).");
+
+  if (issues.length === 0) {
+    gate.style.display = "none";
+    next.disabled = false;
+  } else {
+    gate.style.display = "";
+    gate.classList.toggle("is-error", issues.some(i => i.includes("isn't installed")));
+    text.textContent = issues.join(" ");
+    next.disabled = true;
+  }
+}
+
+$("arc-quit-btn").addEventListener("click", async () => {
+  const btn = $("arc-quit-btn");
+  setLoading(btn, true, "Quitting Arc");
+  await Bridge().quit_browser("arc"); await sleep(400);
+  await runDetect();
+  setLoading(btn, false);
+});
+$("zen-quit-btn").addEventListener("click", async () => {
+  const btn = $("zen-quit-btn");
+  setLoading(btn, true, "Quitting Zen");
+  await Bridge().quit_browser("zen"); await sleep(400);
+  await runDetect();
+  setLoading(btn, false);
+});
+$("detect-recheck").addEventListener("click", () => runDetect());
+$("detect-back").addEventListener("click", () => setScreen("welcome"));
+$("detect-next").addEventListener("click", () => goToPreview());
+$("zen-install-btn").addEventListener("click", () => {
+  const api = Bridge();
+  if (api) api.open_url("https://zen-browser.app/");
+});
+
+// ---- preview --------------------------------------------------------------
+
+async function goToPreview() {
+  setScreen("preview");
+  replace($("stat-strip"), el("span", {class: "muted", text: "Reading Arc data…"}));
+  clear($("spaces-list"));
+  clear($("toggles"));
+
+  const api = Bridge();
+  const opts = currentOptionsJson();
+  const preview = await api.preview(opts);
+  if (preview && preview.error) {
+    replace($("stat-strip"), el("span", {class: "muted", text: preview.error}));
+    return;
+  }
+  state.preview = preview;
+  renderPreview(preview);
+}
+
+function renderPreview(p) {
+  const strip = $("stat-strip");
+  clear(strip);
+  for (const [n, lbl] of [
+    [p.spaces.length, "Spaces"],
+    [p.pinnedTotal, "Pinned tabs"],
+    [p.openTotal, "Open tabs"],
+    [p.folderTotal, "Folders"],
+    [p.bookmarkTotal, "Bookmarks"],
+    [p.faviconMatchEstimate, "Favicons"],
+  ]) {
+    strip.appendChild(makeStat(n, lbl));
+  }
+
+  const list = $("spaces-list"); clear(list);
+  for (const s of p.spaces) list.appendChild(makeSpaceRow(s));
+
+  const toggles = $("toggles"); clear(toggles);
+  toggles.appendChild(makeToggle("includeOpenTabs", "Open tabs",
+                                 `Migrate ${p.openTotal} open tabs`));
+  toggles.appendChild(makeToggle("includeHistory", "Browsing history",
+                                 `Copy ~${formatRows(p.historyRowsEstimate)} history rows`));
+  toggles.appendChild(makeToggle("includeCookies", "Cookies & login state",
+                                 `Copy ~${formatRows(p.cookiesEstimate)} cookies (Keychain prompt)`));
+  toggles.appendChild(makeToggle("foldersCollapsed", "Collapse folders",
+                                 "Imported folders start collapsed"));
+}
+
+function makeStat(n, lbl) {
+  return el("div", {class: "stat"}, [
+    el("span", {class: "num", text: formatRows(n)}),
+    el("span", {class: "lbl", text: lbl}),
+  ]);
+}
+
+function makeSpaceRow(s) {
+  return el("div", {class: "space-row"}, [
+    el("div", {class: "icon", text: s.icon || "·"}),
+    el("div", {}, [
+      el("div", {class: "name", text: s.name}),
+      el("div", {class: "meta", text:
+        `${s.folderCount} folder${s.folderCount === 1 ? "" : "s"}` +
+        (s.essentialCount ? ` · ${s.essentialCount} essential` : "")}),
+    ]),
+    el("div", {class: "count", text: `${s.pinnedCount} tabs`}),
+  ]);
+}
+
+function makeToggle(key, label, desc) {
+  const node = el("div", {
+    class: "toggle",
+    dataset: {key, on: state.options[key] ? "true" : "false"},
+    onclick: () => {
+      state.options[key] = !state.options[key];
+      node.dataset.on = state.options[key] ? "true" : "false";
+    },
+  }, [
+    el("div", {class: "label-stack"}, [
+      el("span", {class: "lbl", text: label}),
+      el("span", {class: "desc", text: desc}),
+    ]),
+    el("div", {class: "switch"}),
+  ]);
+  return node;
+}
+
+$("preview-back").addEventListener("click", () => goToDetect());
+$("preview-go").addEventListener("click", () => goToProgress());
+
+// ---- progress -------------------------------------------------------------
+
+// ---- step icons (inline SVG built via DOM, no string parsing) ----------
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function svgChild(parent, tag, attrs) {
+  const node = document.createElementNS(SVG_NS, tag);
+  for (const [k, v] of Object.entries(attrs || {})) node.setAttribute(k, String(v));
+  parent.appendChild(node);
+  return node;
+}
+
+const STEP_ICON_BUILDERS = {
+  extract: (s) => {
+    svgChild(s, "path", {d: "M5 2 L11 2 L14 5 L14 16 L4 16 L4 2 Z"});
+    svgChild(s, "path", {d: "M11 2 L11 5 L14 5"});
+    svgChild(s, "path", {d: "M6 9 L12 9"});
+    svgChild(s, "path", {d: "M6 12 L12 12"});
+  },
+  containers: (s) => {
+    svgChild(s, "path", {d: "M9 2 L15 5 L9 8 L3 5 Z"});
+    svgChild(s, "path", {d: "M3 9 L9 12 L15 9"});
+    svgChild(s, "path", {d: "M3 12 L9 15 L15 12"});
+  },
+  sessions: (s) => {
+    svgChild(s, "rect", {x: 2.5, y: 3, width: 13, height: 12, rx: 1.5});
+    svgChild(s, "line", {x1: 2.5, y1: 6.5, x2: 15.5, y2: 6.5});
+  },
+  bookmarks: (s) => svgChild(s, "path", {d: "M5 2 L13 2 L13 16 L9 13 L5 16 Z"}),
+  favicons: (s) => {
+    svgChild(s, "rect", {x: 2.5, y: 3, width: 13, height: 12, rx: 1.5});
+    svgChild(s, "circle", {cx: 6.5, cy: 7, r: 1.3, fill: "currentColor", stroke: "none"});
+    svgChild(s, "path", {d: "M2.5 13 L7 9 L11 12 L15.5 8"});
+  },
+  open_tabs: (s) => {
+    svgChild(s, "rect", {x: 3, y: 4, width: 11, height: 11, rx: 1.5});
+    svgChild(s, "rect", {x: 6, y: 2, width: 9, height: 3, rx: 1});
+  },
+  history: (s) => {
+    svgChild(s, "circle", {cx: 9, cy: 9, r: 6.5});
+    svgChild(s, "path", {d: "M9 5 L9 9 L12 11", "stroke-linecap": "round"});
+  },
+  cookies: (s) => {
+    svgChild(s, "circle", {cx: 6, cy: 9, r: 3.5});
+    svgChild(s, "path", {d: "M9.5 9 L16 9", "stroke-linecap": "round"});
+    svgChild(s, "path", {d: "M14 9 L14 12", "stroke-linecap": "round"});
+    svgChild(s, "path", {d: "M16 9 L16 11.5", "stroke-linecap": "round"});
+  },
+  finalize: (s) => svgChild(s, "path", {d: "M3 9 L7.5 13 L15 5",
+                                         "stroke-width": 2, "stroke-linecap": "round", "stroke-linejoin": "round"}),
+};
+
+function makeStepIcon(step) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 18 18");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "1.5");
+  svg.setAttribute("stroke-linejoin", "round");
+  const builder = STEP_ICON_BUILDERS[step] || STEP_ICON_BUILDERS.sessions;
+  builder(svg);
+  return svg;
+}
+
+// ---- step descriptions + streaming patterns -----------------------------
+
+const STEP_SUBTITLES = {
+  extract:    "Reading Arc's StorableSidebar.json",
+  containers: "Setting up cookie-isolated containers per space",
+  sessions:   "Writing spaces, pinned tabs and folders to zen-sessions.jsonlz4",
+  bookmarks:  "Mirroring pinned tabs as Firefox bookmarks",
+  favicons:   "Decoding Arc's icon cache and inlining into Zen tabs",
+  open_tabs:  "Creating Zen sessionstore entries",
+  history:    "Copying browsing history into places.sqlite",
+  cookies:    "Decrypting Arc cookies via Keychain and writing to cookies.sqlite",
+  finalize:   "Marking migration complete",
+};
+
+// Each pattern returns {detail, percent?} when matched against a log line.
+// We use String.prototype.match (no regex.exec) so it composes cleanly.
+const STREAM_PATTERNS = {
+  extract: [
+    [/Found (\d+) spaces with pinned tabs/, m => ({detail: `Found ${m[1]} spaces`})],
+    [/✅ ([^:]+): (\d+) pinned tabs/,        m => ({detail: `Read ${m[1].trim()}: ${m[2]} pinned tabs`})],
+  ],
+  containers: [
+    [/Creating containers? for (\d+)/, m => ({detail: `Creating ${m[1]} containers`})],
+    [/Reusing existing container/,     () => ({detail: "Reusing existing container"})],
+  ],
+  sessions: [
+    [/Importing pinned tabs? \(workspace ([^)]+)\)/, m => ({detail: `Workspace: ${m[1]}`})],
+    [/Imported (\d+) pinned tabs/,                   m => ({detail: `Imported ${m[1]} pinned tabs`})],
+    [/Backed up zen-sessions/,                       () => ({detail: "Backed up zen-sessions.jsonlz4"})],
+  ],
+  bookmarks: [
+    [/Creating bookmark folder/, () => ({detail: "Creating bookmark folders"})],
+    [/Imported: (\d+) bookmarks/, m => ({detail: `Imported ${m[1]} bookmarks`})],
+  ],
+  favicons: [
+    [/Reading Arc favicons from (\S+)/,     m => ({detail: `Reading ${m[1]} profile`})],
+    [/Matched favicons for (\d+) of (\d+)/, m => ({detail: `Matched ${m[1]} of ${m[2]}`, percent: +m[1] / +m[2]})],
+    [/Backed up favicons/,                  () => ({detail: "Backed up favicons.sqlite"})],
+    [/Imported (\d+) favicons/,             m => ({detail: `Imported ${m[1]} favicons`})],
+    [/Injected favicons into (\d+) tabs/,   m => ({detail: `Inlined favicons into ${m[1]} tabs`})],
+  ],
+  history: [
+    [/Reading Arc history from (\S+)/,                                    m => ({detail: `Reading ${m[1]} profile`})],
+    [/Aggregated (\d+) URLs from Arc history \((\d+) visits\)/,           m => ({detail: `Aggregated ${formatRows(+m[1])} URLs / ${formatRows(+m[2])} visits`})],
+    [/Backed up places\.sqlite/,                                          () => ({detail: "Backed up places.sqlite"})],
+    [/History: \+(\d+) new places, ~(\d+) merged, \+(\d+) visits/,        m => ({detail: `+${formatRows(+m[1])} places, +${formatRows(+m[3])} visits`})],
+  ],
+  cookies: [
+    [/Reading Arc cookies from (\S+)/,                            m => ({detail: `Reading ${m[1]} profile`})],
+    [/Decrypted (\d+) encrypted cookie/,                          m => ({detail: `Decrypted ${formatRows(+m[1])} cookies`})],
+    [/Decoded (\d+) of (\d+) cookies/,                            m => ({detail: `Decoded ${m[1]} of ${m[2]}`, percent: +m[1] / +m[2]})],
+    [/Backed up cookies/,                                         () => ({detail: "Backed up cookies.sqlite"})],
+    [/Cookies: imported (\d+), merged (\d+) across (\d+)/,        m => ({detail: `${formatRows(+m[1])} imported across ${m[3]} contexts`})],
+  ],
+};
+
+function applyStreamingMatch(step, message) {
+  const patterns = STREAM_PATTERNS[step]; if (!patterns) return null;
+  for (const [re, fn] of patterns) {
+    const m = String(message).match(re);
+    if (m) return fn(m);
+  }
+  return null;
+}
+
+// ---- progress flow -------------------------------------------------------
+
+async function goToProgress() {
+  setScreen("progress");
+
+  const api = Bridge();
+  const meta = await api.get_step_metadata();
+  state.steps = meta.steps;
+  state.stepLabels = meta.labels;
+  state.stepStates = Object.fromEntries(state.steps.map(s => [s, "pending"]));
+  state.stepSummaries = {};
+  state.logLines = [];
+  state.activeStep = null;
+  state.activeDetail = "";
+  state.activeProgress = null;
+  state.startedAt = Date.now();
+
+  if (state.elapsedHandle) clearInterval(state.elapsedHandle);
+  state.elapsedHandle = setInterval(updateElapsed, 1000);
+  updateElapsed();
+
+  renderProgress();
+
+  await api.start_migration(currentOptionsJson());
+  state.pollHandle = setInterval(pollProgress, 120);
+}
+
+function updateElapsed() {
+  const sec = Math.max(0, Math.floor((Date.now() - state.startedAt) / 1000));
+  const mm = Math.floor(sec / 60);
+  const ss = String(sec % 60).padStart(2, "0");
+  $("elapsed").textContent = `${mm}:${ss}`;
+}
+
+async function pollProgress() {
+  const api = Bridge(); if (!api) return;
+  const data = await api.drain_progress();
+  for (const ev of (data.events || [])) handleEvent(ev);
+  if (data.state && data.state.status === "done") {
+    clearInterval(state.pollHandle); state.pollHandle = null;
+    if (state.elapsedHandle) { clearInterval(state.elapsedHandle); state.elapsedHandle = null; }
+    finishOk(data.state);
+  } else if (data.state && data.state.status === "error") {
+    clearInterval(state.pollHandle); state.pollHandle = null;
+    if (state.elapsedHandle) { clearInterval(state.elapsedHandle); state.elapsedHandle = null; }
+    finishError(data.state);
+  }
+}
+
+function handleEvent(ev) {
+  if (ev.kind === "step_start") {
+    state.stepStates[ev.step] = "active";
+    state.activeStep = ev.step;
+    state.activeDetail = "";
+    state.activeProgress = null;
+  } else if (ev.kind === "step_done") {
+    state.stepStates[ev.step] = "done";
+    if (ev.summary) state.stepSummaries[ev.step] = ev.summary;
+    if (state.activeStep === ev.step) {
+      state.activeStep = null;
+      state.activeDetail = "";
+      state.activeProgress = null;
+    }
+  } else if (ev.kind === "step_error") {
+    state.stepStates[ev.step] = "error";
+  } else {
+    state.logLines.push({kind: ev.kind, message: ev.message, step: ev.step});
+    if (state.logLines.length > 500) state.logLines.shift();
+    if (state.activeStep && (ev.step === state.activeStep || !ev.step)) {
+      const match = applyStreamingMatch(state.activeStep, ev.message);
+      if (match) {
+        if (match.detail !== undefined) state.activeDetail = match.detail;
+        if (match.percent !== undefined) state.activeProgress = match.percent;
+      }
+    }
+  }
+  renderProgress();
+  renderLog();
+}
+
+function visibleSteps() {
+  return state.steps.filter(s => {
+    if (s === "open_tabs") return state.options.includeOpenTabs;
+    if (s === "history")   return state.options.includeHistory;
+    if (s === "cookies")   return state.options.includeCookies;
+    if (s === "containers" || s === "sessions") return state.options.includeWorkspaces || state.options.includePinnedTabs;
+    if (s === "bookmarks") return state.options.includeBookmarks;
+    if (s === "favicons")  return state.options.includeFavicons;
+    return true;
+  });
+}
+
+function renderProgress() {
+  const steps = visibleSteps();
+
+  // top meter
+  const meter = $("meter"); clear(meter);
+  for (const s of steps) {
+    meter.appendChild(el("div", {class: "meter-segment",
+                                  dataset: {state: state.stepStates[s] || "pending", step: s}}));
+  }
+
+  const activeIdx = steps.findIndex(s => state.stepStates[s] === "active");
+  const total = steps.length;
+  const meta = $("progress-meta");
+  if (activeIdx >= 0)                                          meta.textContent = `Step ${activeIdx + 1} of ${total}`;
+  else if (steps.every(s => state.stepStates[s] === "done"))   meta.textContent = `${total} of ${total} done`;
+  else                                                         meta.textContent = "Working";
+
+  // unified timeline
+  const tl = $("timeline"); clear(tl);
+  for (const s of steps) {
+    const st = state.stepStates[s] || "pending";
+    if (st === "active") {
+      tl.appendChild(makeActiveRow(s));
+    } else {
+      tl.appendChild(makeRow(s, st));
+    }
+  }
+}
+
+function makeRow(step, st) {
+  const summary = (st === "done") ? stepSummaryText(step, state.stepSummaries[step]) : "";
+  return el("li", {class: "tl-step", dataset: {step, state: st}}, [
+    el("div", {class: "ico"}, [makeStepIcon(step)]),
+    el("span", {class: "lbl", text: state.stepLabels[step] || step}),
+    el("span", {class: "summary", text: summary}),
+  ]);
+}
+
+function makeActiveRow(step) {
+  const live = el("div", {class: "live"});
+  live.appendChild(el("div", {class: "detail", text: state.activeDetail || ""}));
+  if (state.activeProgress != null) {
+    const fill = el("span");
+    fill.style.width = `${Math.round(state.activeProgress * 100)}%`;
+    live.appendChild(el("div", {class: "bar"}, [fill]));
+  }
+  return el("li", {class: "tl-step", dataset: {step, state: "active"}}, [
+    el("div", {class: "ico"}, [makeStepIcon(step)]),
+    el("span", {class: "lbl", text: state.stepLabels[step] || step}),
+    el("span", {class: "subtitle", text: STEP_SUBTITLES[step] || ""}),
+    live,
+  ]);
+}
+
+function stepSummaryText(step, s) {
+  if (!s) return "";
+  if (step === "extract")    return `${s.spaces ?? "?"} spaces · ${s.pinned ?? "?"} tabs`;
+  if (step === "containers") return `${s.created_or_reused ?? "?"} containers`;
+  if (step === "favicons") {
+    const db = s.db || {}; const sess = s.session || {};
+    return `${formatRows(db.imported ?? 0)} icons · ${formatRows(sess.updated ?? 0)} tabs inlined`;
+  }
+  if (step === "history") return `${formatRows(s.places_added ?? 0)} places · ${formatRows(s.visits_added ?? 0)} visits`;
+  if (step === "cookies") return `${formatRows(s.imported ?? 0)} imported · ${formatRows(s.merged ?? 0)} merged`;
+  if (step === "bookmarks" || step === "sessions" || step === "open_tabs") return s.ok ? "ok" : "";
+  return "";
+}
+
+function renderLog() {
+  const wrap = $("log"); clear(wrap);
+  const recent = state.logLines.slice(-200);
+  for (const l of recent) {
+    const cls = l.kind === "warn" ? "warn" : (l.kind === "step_error" ? "err" : "");
+    wrap.appendChild(el("div", {class: cls, text: l.message}));
+  }
+  wrap.scrollTop = wrap.scrollHeight;
+}
+
+// ---- done -----------------------------------------------------------------
+
+async function finishOk(finalState) {
+  setScreen("done");
+  const api = Bridge();
+  const ext = state.stepSummaries.extract || {};
+  const subtitle = ext.pinned
+    ? `${ext.pinned} pinned tabs across ${ext.spaces} spaces. Backups saved next to your Zen profile.`
+    : `Backups saved next to your Zen profile.`;
+  $("done-summary").textContent = subtitle;
+
+  const list = $("backups-list"); clear(list);
+  const backups = (finalState.backups || []).slice(-12).reverse();
+  for (const path of backups) {
+    list.appendChild(el("li", {
+      dataset: {path},
+      text: shortenPath(path),
+      onclick: () => api.open_path_in_finder(path),
+    }));
+  }
+}
+
+$("done-launch").addEventListener("click", async () => {
+  const api = Bridge(); if (!api) return;
+  // Don't await quit_app — calling window.destroy() while a JS-Python promise
+  // is still pending leaves WKWebView waiting for a reply that never comes,
+  // which looks like the window "hanging on loading".
+  try { await api.launch_zen(); } catch (e) { /* best-effort */ }
+  setTimeout(() => { api.quit_app(); }, 80);
+});
+$("done-quit").addEventListener("click", async () => {
+  const api = Bridge(); if (api) api.quit_app();
+});
+
+// ---- error ----------------------------------------------------------------
+
+function finishError(finalState) {
+  setScreen("error");
+  $("error-summary").textContent = finalState.error || "Something went wrong.";
+  const detail = (finalState.trace || "") + "\n\n" + state.logLines.map(l => `[${l.kind}] ${l.message}`).join("\n");
+  $("error-body").textContent = detail.trim();
+}
+
+$("error-quit").addEventListener("click", async () => {
+  const api = Bridge(); if (api) api.quit_app();
+});
+$("error-copy").addEventListener("click", async () => {
+  const api = Bridge();
+  if (api) await api.copy_to_clipboard($("error-body").textContent);
+});
+
+// ---- backups screen ----------------------------------------------------
+
+const BACKUP_GROUP_LABELS = {
+  "zen-sessions.jsonlz4": ["Sessions", "Workspaces, pinned tabs, folders, inline favicons"],
+  "favicons.sqlite":      ["Favicons",  "Per-page favicon cache"],
+  "places.sqlite":        ["Places",    "Bookmarks and browsing history"],
+  "cookies.sqlite":       ["Cookies",   "Login state and per-container cookies"],
+};
+
+$("open-backups").addEventListener("click", () => goToBackups());
+$("backups-back").addEventListener("click", () => setScreen("welcome"));
+$("backups-refresh").addEventListener("click", () => loadBackups());
+
+async function goToBackups() {
+  setScreen("backups");
+  await loadBackups();
+}
+
+async function loadBackups() {
+  const api = await whenBridgeReady();
+  const list = await api.list_backups();
+  renderBackups(list || []);
+}
+
+function renderBackups(items) {
+  const groups = $("backups-groups");
+  clear(groups);
+
+  if (!items.length) { $("backups-empty").style.display = ""; return; }
+  $("backups-empty").style.display = "none";
+
+  // group by `original`
+  const byOriginal = new Map();
+  for (const it of items) {
+    if (!byOriginal.has(it.original)) byOriginal.set(it.original, []);
+    byOriginal.get(it.original).push(it);
+  }
+  // sort each group's entries newest first (already from server, but defensive)
+  for (const arr of byOriginal.values()) arr.sort((a, b) => b.ts - a.ts);
+
+  // render in known order, then unknown
+  const known = Object.keys(BACKUP_GROUP_LABELS);
+  const ordered = [
+    ...known.filter(k => byOriginal.has(k)),
+    ...[...byOriginal.keys()].filter(k => !known.includes(k)),
+  ];
+
+  for (const original of ordered) {
+    const entries = byOriginal.get(original);
+    const [label, desc] = BACKUP_GROUP_LABELS[original] || [original, ""];
+
+    const group = el("div", {class: "backup-group"});
+    group.appendChild(el("h3", {text: label + " · " + original}));
+    if (desc) group.appendChild(el("p", {class: "desc", text: desc}));
+    const ul = el("ul", {class: "backup-list"});
+    for (const e of entries) ul.appendChild(makeBackupRow(e));
+    group.appendChild(ul);
+    groups.appendChild(group);
+  }
+}
+
+function makeBackupRow(entry) {
+  return el("li", {class: "backup-row"}, [
+    el("span", {class: "ts", text: entry.iso}),
+    el("span", {class: "size", text: humanSize(entry.size)}),
+    el("button", {
+      class: "btn btn-soft btn-pill",
+      text: "Restore",
+      onclick: async () => {
+        const api = Bridge();
+        const r = await api.restore_backup(entry.path);
+        if (r && r.ok) {
+          await loadBackups();
+        } else {
+          alert("Restore failed: " + (r && r.error || "unknown error"));
+        }
+      },
+    }),
+    el("button", {
+      class: "btn btn-soft btn-pill btn-danger",
+      text: "Delete",
+      onclick: async () => {
+        const api = Bridge();
+        const r = await api.delete_backup(entry.path);
+        if (r && r.ok) await loadBackups();
+        else alert("Delete failed: " + (r && r.error || "unknown error"));
+      },
+    }),
+  ]);
+}
+
+function humanSize(b) {
+  if (b == null) return "—";
+  if (b < 1024) return b + " B";
+  if (b < 1024 * 1024) return (b / 1024).toFixed(1) + " KB";
+  if (b < 1024 * 1024 * 1024) return (b / (1024*1024)).toFixed(1) + " MB";
+  return (b / (1024*1024*1024)).toFixed(2) + " GB";
+}
+
+// ---- utilities -----------------------------------------------------------
+
+function currentOptionsJson() {
+  return JSON.stringify({
+    zenProfilePath: state.selectedZenProfile,
+    arcSpaceFilter: null,
+    foldersCollapsed: state.options.foldersCollapsed,
+    includeWorkspaces: state.options.includeWorkspaces,
+    includePinnedTabs: state.options.includePinnedTabs,
+    includeBookmarks: state.options.includeBookmarks,
+    includeFavicons: state.options.includeFavicons,
+    includeOpenTabs: state.options.includeOpenTabs,
+    includeHistory: state.options.includeHistory,
+    includeCookies: state.options.includeCookies,
+  });
+}
+
+function formatRows(n) {
+  if (n == null) return "-";
+  if (n < 1000) return String(n);
+  if (n < 1e6)  return `${(n / 1000).toFixed(n < 10000 ? 1 : 0)}k`;
+  return `${(n / 1e6).toFixed(1)}M`;
+}
+
+function shortenPath(p) {
+  const home = "/Users/";
+  if (p.startsWith(home)) {
+    const idx = p.indexOf("/", home.length);
+    if (idx > 0) return "~" + p.slice(idx);
+  }
+  return p;
+}
+
+// ---- bootstrap ------------------------------------------------------------
+
+window.addEventListener("pywebviewready", () => {
+  decorateBranding();
+  setScreen("welcome");
+});
+setTimeout(() => {
+  if (!Bridge()) return;
+  decorateBranding();
+  setScreen("welcome");
+}, 200);

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -62,7 +62,7 @@ const state = {
     includePinnedTabs: true,
     includeBookmarks: true,
     includeFavicons: true,
-    includeOpenTabs: false,
+    includeOpenTabs: true,
     includeHistory: false,
     includeCookies: false,
   },

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -368,9 +368,10 @@ function makeStat(n, lbl) {
 }
 
 function makeSpaceRow(s) {
-  return el("div", {class: "space-row"}, [
+  const hasColor = Array.isArray(s.color) && s.color.length === 3;
+  const row = el("div", {class: hasColor ? "space-row" : "space-row no-color"}, [
     el("div", {class: "icon", text: s.icon || "·"}),
-    el("div", {}, [
+    el("div", {class: "text"}, [
       el("div", {class: "name", text: s.name}),
       el("div", {class: "meta", text:
         `${s.folderCount} folder${s.folderCount === 1 ? "" : "s"}` +
@@ -378,6 +379,13 @@ function makeSpaceRow(s) {
     ]),
     el("div", {class: "count", text: `${s.pinnedCount} tabs`}),
   ]);
+  if (hasColor) {
+    const [r, g, b] = s.color;
+    row.style.setProperty("--space-tint-r", r);
+    row.style.setProperty("--space-tint-g", g);
+    row.style.setProperty("--space-tint-b", b);
+  }
+  return row;
 }
 
 function makeToggle(key, label, desc) {
@@ -895,14 +903,28 @@ async function setPlatformAttribute() {
   } catch (_) { /* best effort */ }
 }
 
+async function setAppVersion() {
+  const api = Bridge();
+  if (!api) return;
+  try {
+    const v = await api.version();
+    if (typeof v === "string" && v) {
+      const node = $("ver");
+      if (node) node.textContent = `arc2zen · v${v}`;
+    }
+  } catch (_) { /* best effort */ }
+}
+
 window.addEventListener("pywebviewready", () => {
   setPlatformAttribute();
+  setAppVersion();
   decorateBranding();
   setScreen("welcome");
 });
 setTimeout(() => {
   if (!Bridge()) return;
   setPlatformAttribute();
+  setAppVersion();
   decorateBranding();
   setScreen("welcome");
 }, 200);

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -621,7 +621,6 @@ function handleEvent(ev) {
 
 function visibleSteps() {
   return state.steps.filter(s => {
-    if (s === "open_tabs") return state.options.includeOpenTabs;
     if (s === "history")   return state.options.includeHistory;
     if (s === "cookies")   return state.options.includeCookies;
     if (s === "containers" || s === "sessions") return state.options.includeWorkspaces || state.options.includePinnedTabs;
@@ -695,7 +694,14 @@ function stepSummaryText(step, s) {
   }
   if (step === "history") return `${formatRows(s.places_added ?? 0)} places · ${formatRows(s.visits_added ?? 0)} visits`;
   if (step === "cookies") return `${formatRows(s.imported ?? 0)} imported · ${formatRows(s.merged ?? 0)} merged`;
-  if (step === "bookmarks" || step === "sessions" || step === "open_tabs") return s.ok ? "ok" : "";
+  if (step === "sessions") {
+    if (s.pinned == null && s.open == null) return s.ok ? "ok" : "";
+    const parts = [];
+    if (s.pinned) parts.push(`${formatRows(s.pinned)} pinned`);
+    if (s.open)   parts.push(`${formatRows(s.open)} open`);
+    return parts.join(" · ") || (s.ok ? "ok" : "");
+  }
+  if (step === "bookmarks") return s.ok ? "ok" : "";
   return "";
 }
 

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=760, initial-scale=1" />
+  <title>Arc2Zen</title>
+  <link rel="stylesheet" href="tokens.css" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body data-screen="welcome">
+
+  <!-- ------------------------------------------------ titlebar -->
+  <div class="titlebar">
+    <div class="tl">
+      <button class="tl-close" id="tl-close" aria-label="Close"></button>
+      <button class="tl-min" id="tl-min" aria-label="Minimize" disabled></button>
+      <button class="tl-max" id="tl-max" aria-label="Maximize" disabled></button>
+    </div>
+    <span class="ver" id="ver">arc2zen · v0.1</span>
+  </div>
+
+  <main>
+    <!-- ============================================ welcome -->
+    <section class="screen" id="screen-welcome">
+      <div class="hero">
+        <div class="brand-pair" id="brand-pair"></div>
+        <p class="eyebrow">Arc → Zen</p>
+        <h1 class="display">Move your browser, keep your setup.</h1>
+        <p class="muted" style="margin-top: var(--space-3); max-width: 520px; line-height: 1.5;">
+          Spaces, pinned tabs, folders, favicons, bookmarks. Optionally history and
+          login state. Done in under a minute.
+        </p>
+      </div>
+      <div class="actions">
+        <button class="btn btn-primary" id="welcome-go">Let's go</button>
+      </div>
+      <div class="footer">
+        <span>arc2zen · open source</span>
+        <button class="link-btn" id="open-backups">Manage backups</button>
+        <span>macOS · arm64</span>
+      </div>
+    </section>
+
+    <!-- ============================================ detect -->
+    <section class="screen" id="screen-detect">
+      <p class="eyebrow">Step 1 of 3</p>
+      <h1 class="h1">Let's find your browsers.</h1>
+      <p class="muted" style="margin-top: 4px;">Both browsers must be quit before we can read and write their data safely.</p>
+
+      <div class="detect-grid">
+        <div class="browser-card" id="card-arc" data-ok="false">
+          <div class="card-head">
+            <span class="brand-mark" id="arc-mark"></span>
+            <span class="h2">Arc</span>
+            <span class="pill pill-warn" id="arc-pill">Detecting…</span>
+          </div>
+          <div class="subtle muted" id="arc-detail">Looking for Arc data on disk.</div>
+          <div id="arc-running-row" style="display:none;">
+            <button class="btn btn-soft btn-pill" id="arc-quit-btn">Quit Arc</button>
+          </div>
+        </div>
+
+        <div class="browser-card" id="card-zen" data-ok="false">
+          <div class="card-head">
+            <span class="brand-mark" id="zen-mark"></span>
+            <span class="h2">Zen</span>
+            <span class="pill pill-warn" id="zen-pill">Detecting…</span>
+          </div>
+          <div class="subtle muted" id="zen-detail">Looking for Zen profiles on disk.</div>
+          <select class="profile-select" id="zen-profile-select" style="display:none;"></select>
+          <div id="zen-install-row" style="display:none;">
+            <button class="btn btn-primary btn-pill" id="zen-install-btn">Download Zen</button>
+            <span class="subtle dim" style="margin-left: var(--space-3);">Then launch it once and click Recheck.</span>
+          </div>
+          <div id="zen-running-row" style="display:none;">
+            <button class="btn btn-soft btn-pill" id="zen-quit-btn">Quit Zen</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="gate" id="detect-gate" style="display:none;">
+        <span id="detect-gate-text"></span>
+        <button class="btn btn-soft btn-pill" id="detect-recheck">Recheck</button>
+      </div>
+
+      <div class="actions-row">
+        <button class="btn btn-ghost" id="detect-back">Back</button>
+        <button class="btn btn-primary" id="detect-next" disabled>Continue</button>
+      </div>
+    </section>
+
+    <!-- ============================================ preview -->
+    <section class="screen" id="screen-preview">
+      <p class="eyebrow">Step 2 of 3</p>
+      <h1 class="h1" id="preview-title">Here's what we found.</h1>
+      <p class="muted" style="margin-top: 4px;">Review and choose what to bring over.</p>
+
+      <div class="stat-strip" id="stat-strip"></div>
+
+      <div class="spaces-list" id="spaces-list"></div>
+
+      <p class="eyebrow" style="margin-top: var(--space-6);">Optional</p>
+      <div class="toggles" id="toggles"></div>
+
+      <div class="actions-row">
+        <button class="btn btn-ghost" id="preview-back">Back</button>
+        <button class="btn btn-primary" id="preview-go">Start migration</button>
+      </div>
+    </section>
+
+    <!-- ============================================ progress -->
+    <section class="screen" id="screen-progress">
+      <header class="progress-head">
+        <div>
+          <p class="eyebrow" id="progress-meta">Working</p>
+          <h1 class="display">Migrating</h1>
+          <p class="muted" id="progress-sub" style="margin-top: 4px;">Bringing your Arc setup into Zen.</p>
+        </div>
+        <span class="elapsed" id="elapsed" aria-live="polite">0:00</span>
+      </header>
+
+      <div class="meter" id="meter" aria-hidden="true"></div>
+
+      <ol class="timeline" id="timeline" aria-live="polite"></ol>
+
+      <details class="details">
+        <summary>View log</summary>
+        <div class="log" id="log"></div>
+      </details>
+    </section>
+
+    <!-- ============================================ done -->
+    <section class="screen" id="screen-done">
+      <div class="check">
+        <svg viewBox="0 0 24 24" fill="none">
+          <path d="M5 12 L10 17 L19 7" stroke="var(--success)" stroke-width="2.6"
+                stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <h1 class="display">All set.</h1>
+      <p class="summary" id="done-summary">Your Arc setup now lives in Zen.</p>
+      <div class="actions">
+        <button class="btn btn-primary" id="done-launch">Launch Zen</button>
+        <button class="btn btn-ghost" id="done-quit">Quit</button>
+      </div>
+      <div class="backups">
+        <p class="eyebrow">Backups (click to reveal)</p>
+        <ul id="backups-list"></ul>
+      </div>
+    </section>
+
+    <!-- ============================================ backups -->
+    <section class="screen" id="screen-backups">
+      <header class="progress-head">
+        <div>
+          <p class="eyebrow">Backups</p>
+          <h1 class="h1">Restore an earlier state.</h1>
+          <p class="muted" style="margin-top: 4px;">Every migration writes timestamped backups beside your Zen profile. Pick one to restore or delete files you no longer need.</p>
+        </div>
+      </header>
+
+      <div id="backups-empty" class="muted" style="margin-top: var(--space-6); display:none;">No backups found yet.</div>
+      <div id="backups-groups" style="margin-top: var(--space-4);"></div>
+
+      <div class="actions-row">
+        <button class="btn btn-ghost" id="backups-back">Back</button>
+        <button class="btn btn-soft" id="backups-refresh">Refresh</button>
+      </div>
+    </section>
+
+    <!-- ============================================ error -->
+    <section class="screen" id="screen-error">
+      <div class="icon">!</div>
+      <h1 class="h1">Migration didn't complete.</h1>
+      <p class="muted" id="error-summary" style="margin-top: 4px;">A step failed. Backups were created before each write so your Zen data is safe.</p>
+      <div class="body" id="error-body"></div>
+      <div class="actions-row">
+        <button class="btn btn-ghost" id="error-quit">Quit</button>
+        <button class="btn btn-soft" id="error-copy">Copy report</button>
+      </div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -16,7 +16,7 @@
       <button class="tl-min" id="tl-min" aria-label="Minimize" disabled></button>
       <button class="tl-max" id="tl-max" aria-label="Maximize" disabled></button>
     </div>
-    <span class="ver" id="ver">arc2zen · v0.1</span>
+    <span class="ver" id="ver">arc2zen</span>
   </div>
 
   <main>

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -25,7 +25,10 @@ button:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
 
 /* ---------------------- window chrome ---------------------- */
 
-.titlebar {
+/* Fake titlebar / traffic lights only on macOS, where the window is
+   frameless. On Windows we let the OS draw the real chrome. */
+.titlebar { display: none; }
+body[data-platform="mac"] .titlebar {
   position: fixed;
   top: 0; left: 0; right: 0;
   height: 36px;
@@ -39,13 +42,13 @@ button:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
   z-index: 100;
 }
 
-.tl {
+body[data-platform="mac"] .tl {
   display: flex;
   gap: 8px;
   -webkit-app-region: no-drag;
   app-region: no-drag;
 }
-.tl button {
+body[data-platform="mac"] .tl button {
   width: 12px;
   height: 12px;
   border-radius: 50%;
@@ -56,12 +59,12 @@ button:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
   transition: background var(--dur-fast) var(--ease-standard);
   position: relative;
 }
-.tl:hover button.tl-close { background: var(--tl-close); }
-.tl:hover button.tl-min   { background: var(--tl-min); }
-.tl:hover button.tl-max   { background: var(--tl-max); }
-.tl button:focus-visible { box-shadow: 0 0 0 2px var(--accent); }
+body[data-platform="mac"] .tl:hover button.tl-close { background: var(--tl-close); }
+body[data-platform="mac"] .tl:hover button.tl-min   { background: var(--tl-min); }
+body[data-platform="mac"] .tl:hover button.tl-max   { background: var(--tl-max); }
+body[data-platform="mac"] .tl button:focus-visible { box-shadow: 0 0 0 2px var(--accent); }
 
-.titlebar .ver {
+body[data-platform="mac"] .titlebar .ver {
   margin-left: auto;
   font-size: var(--fs-tiny);
   color: var(--text-tertiary);
@@ -72,8 +75,12 @@ button:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
 
 main {
   position: absolute;
-  top: 36px; left: 0; right: 0; bottom: 0;
+  top: 0; left: 0; right: 0; bottom: 0;
   display: grid;
+}
+body[data-platform="mac"] main {
+  /* Leave room for the custom titlebar on macOS. */
+  top: 36px;
 }
 .screen {
   grid-area: 1 / 1;

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -1,0 +1,798 @@
+/* ====================================================================
+   Arc2Zen GUI: single-window, multi-screen.
+   Layout: 760×580, frameless, vibrancy on macOS.
+   ==================================================================== */
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  background: var(--bg-vibrancy);
+  color: var(--text-primary);
+  font-family: var(--font-text);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-regular);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: -0.01em;
+}
+
+button { font-family: inherit; }
+button:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+
+/* ---------------------- window chrome ---------------------- */
+
+.titlebar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 36px;
+  padding: 0 var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  -webkit-app-region: drag;
+  app-region: drag;
+  user-select: none;
+  z-index: 100;
+}
+
+.tl {
+  display: flex;
+  gap: 8px;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+.tl button {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  background: var(--tl-idle);
+  transition: background var(--dur-fast) var(--ease-standard);
+  position: relative;
+}
+.tl:hover button.tl-close { background: var(--tl-close); }
+.tl:hover button.tl-min   { background: var(--tl-min); }
+.tl:hover button.tl-max   { background: var(--tl-max); }
+.tl button:focus-visible { box-shadow: 0 0 0 2px var(--accent); }
+
+.titlebar .ver {
+  margin-left: auto;
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+}
+
+/* ---------------------- screen container ---------------------- */
+
+main {
+  position: absolute;
+  top: 36px; left: 0; right: 0; bottom: 0;
+  display: grid;
+}
+.screen {
+  grid-area: 1 / 1;
+  padding: var(--space-8) var(--space-10) var(--space-6);
+  display: none;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity var(--dur-medium) var(--ease-emphasized),
+              transform var(--dur-medium) var(--ease-emphasized);
+  overflow-y: auto;
+}
+.screen.is-active {
+  display: flex;
+  flex-direction: column;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ---------------------- typography ---------------------- */
+
+.eyebrow {
+  font-size: var(--fs-tiny);
+  font-weight: var(--fw-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+.display {
+  font-family: var(--font-display);
+  font-size: var(--fs-display);
+  font-weight: var(--fw-semibold);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.h1 {
+  font-family: var(--font-display);
+  font-size: var(--fs-h1);
+  font-weight: var(--fw-semibold);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  margin: 0;
+}
+.h2 {
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-semibold);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.muted { color: var(--text-secondary); }
+.dim   { color: var(--text-tertiary); }
+.mono  { font-family: var(--font-mono); font-size: var(--fs-small); }
+.subtle { font-size: var(--fs-small); }
+
+/* ---------------------- buttons ---------------------- */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  height: 36px;
+  padding: 0 var(--space-5);
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--fs-body);
+  font-weight: var(--fw-medium);
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-standard),
+              transform var(--dur-fast) var(--ease-standard),
+              border-color var(--dur-fast) var(--ease-standard),
+              color var(--dur-fast) var(--ease-standard);
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+.btn:active { transform: translateY(0.5px); }
+.btn[disabled] { opacity: 0.45; pointer-events: none; }
+.btn.is-loading { pointer-events: none; opacity: 0.85; }
+.btn.is-loading .spinner { display: inline-block; }
+.btn .spinner {
+  display: none;
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  border-right-color: transparent;
+  animation: spin 700ms linear infinite;
+  margin-right: 4px;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--text-on-accent);
+}
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-primary:active { background: var(--accent-press); }
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-primary);
+  border-color: var(--bd-medium);
+}
+.btn-ghost:hover { background: var(--bg-elev-press); border-color: var(--bd-strong); }
+
+.btn-soft {
+  background: var(--bg-elev);
+  border-color: var(--bd-soft);
+  color: var(--text-primary);
+}
+.btn-soft:hover { background: var(--bg-elev-hi); border-color: var(--bd-medium); }
+
+.btn-danger {
+  background: var(--error);
+  color: white;
+}
+
+.btn-pill {
+  height: 28px;
+  padding: 0 var(--space-3);
+  font-size: var(--fs-small);
+  border-radius: 999px;
+}
+
+/* ---------------------- cards ---------------------- */
+
+.card {
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+}
+.card.elev { box-shadow: var(--shadow-elev1); }
+
+/* ---------------------- screen: welcome ---------------------- */
+
+#screen-welcome { padding: var(--space-12) var(--space-12) var(--space-8); }
+#screen-welcome .hero {
+  margin-top: auto;
+}
+#screen-welcome .actions {
+  margin-top: var(--space-8);
+  display: flex; gap: var(--space-3);
+}
+#screen-welcome .footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+}
+.link-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--text-secondary);
+  text-decoration: underline dotted var(--bd-medium);
+  text-underline-offset: 3px;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+.link-btn:hover { color: var(--text-primary); }
+
+/* ---- Brand marks ---- */
+.brand-pair {
+  display: flex; align-items: center; gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+.brand-pair .arrow {
+  color: var(--text-tertiary);
+  font-size: 22px;
+  font-weight: 300;
+}
+.brand-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 56px; height: 56px;
+  border-radius: 14px;
+  position: relative;
+  flex: 0 0 auto;
+}
+.brand-mark.small { width: 28px; height: 28px; border-radius: 8px; }
+.brand-mark.tiny  { width: 20px; height: 20px; border-radius: 6px; }
+.brand-mark svg { width: 70%; height: 70%; }
+.brand-mark.arc {
+  /* Soft cream/off-white badge so the multicolor A reads cleanly.
+     Subtle warm gradient hints at Arc's pink without competing with the mark. */
+  background: linear-gradient(160deg, #FFF7F2 0%, #FFE9F0 60%, #FFD8E5 100%);
+  box-shadow:
+    0 4px 14px rgba(214, 60, 110, 0.22),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+.brand-mark.arc svg {
+  /* SVG strokes carry their own colors; no filter needed. */
+}
+.brand-mark.zen {
+  background: linear-gradient(160deg, #2B2B2F 0%, #15151A 70%, #0B0B0E 100%);
+  box-shadow:
+    0 6px 18px rgba(0,0,0,0.45),
+    inset 0 0 0 1px rgba(255,255,255,0.10);
+  color: #F2F2F4;          /* white-ish concentric rings */
+}
+.brand-mark.tiny.arc, .brand-mark.tiny.zen { box-shadow: inset 0 0 0 1px rgba(255,255,255,0.12); }
+
+.card-head {
+  display: flex; align-items: center; gap: var(--space-3);
+}
+.card-head .h2 { flex: 1; }
+.card-head .brand-mark { width: 28px; height: 28px; border-radius: 8px; }
+
+/* ---------------------- screen: detect ---------------------- */
+
+.detect-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  margin-top: var(--space-5);
+}
+.browser-card {
+  position: relative;
+  display: flex; flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--dur-medium) var(--ease-standard);
+}
+.browser-card[data-ok="true"]  { border-color: rgba(61, 214, 140, 0.32); }
+.browser-card[data-ok="false"] { border-color: rgba(255, 107, 107, 0.32); }
+
+.browser-card .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: var(--fs-tiny);
+  font-weight: var(--fw-medium);
+}
+.pill-ok    { background: var(--success-soft); color: var(--success); }
+.pill-warn  { background: var(--warn-soft); color: var(--warn); }
+.pill-err   { background: var(--error-soft); color: var(--error); }
+
+.profile-select {
+  width: 100%;
+  height: 36px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev-hi);
+  border: 1px solid var(--bd-medium);
+  color: var(--text-primary);
+  font: inherit;
+  appearance: none;
+  cursor: pointer;
+}
+
+.gate {
+  margin-top: var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--warn-soft);
+  border: 1px solid rgba(244, 184, 81, 0.4);
+  color: var(--text-primary);
+  font-size: var(--fs-small);
+}
+.gate.is-error { background: var(--error-soft); border-color: rgba(255, 107, 107, 0.4); }
+
+.actions-row {
+  margin-top: auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+  padding-top: var(--space-5);
+}
+
+/* ---------------------- screen: preview ---------------------- */
+
+.stat-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  padding: var(--space-4) var(--space-5);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-lg);
+  margin-top: var(--space-4);
+}
+.stat { display: flex; flex-direction: column; gap: 2px; }
+.stat .num {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: var(--fw-semibold);
+  letter-spacing: -0.01em;
+}
+.stat .lbl {
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.spaces-list {
+  margin-top: var(--space-4);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+.space-row {
+  display: grid;
+  grid-template-columns: 32px 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-md);
+}
+.space-row .icon {
+  width: 28px; height: 28px;
+  display: grid; place-items: center;
+  font-size: 18px;
+  background: var(--bg-elev-hi);
+  border-radius: var(--radius-sm);
+}
+.space-row .name { font-weight: var(--fw-medium); }
+.space-row .meta { font-size: var(--fs-tiny); color: var(--text-tertiary); }
+.space-row .count { font-size: var(--fs-small); color: var(--text-secondary); }
+
+.toggles {
+  margin-top: var(--space-5);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+.toggle {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  user-select: none;
+}
+.toggle:hover { border-color: var(--bd-medium); }
+.toggle .label-stack { display: flex; flex-direction: column; gap: 2px; }
+.toggle .lbl { font-weight: var(--fw-medium); }
+.toggle .desc { font-size: var(--fs-tiny); color: var(--text-tertiary); }
+
+.switch {
+  width: 32px; height: 18px;
+  background: var(--bd-medium);
+  border-radius: 999px;
+  position: relative;
+  transition: background var(--dur-fast) var(--ease-standard);
+}
+.switch::after {
+  content: "";
+  position: absolute;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: white;
+  top: 2px; left: 2px;
+  transition: transform var(--dur-fast) var(--ease-standard);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.18);
+}
+.toggle[data-on="true"] .switch { background: var(--accent); }
+.toggle[data-on="true"] .switch::after { transform: translateX(14px); }
+
+/* ---------------------- screen: progress ---------------------- */
+
+.progress-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+.elapsed {
+  font-family: var(--font-mono);
+  font-size: var(--fs-small);
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--bd-soft);
+  background: var(--bg-elev);
+  margin-top: 6px;
+}
+
+.meter {
+  margin-top: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.meter-segment {
+  flex: 1 1 0;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--bd-soft);
+  transition: background var(--dur-medium) var(--ease-standard);
+}
+.meter-segment[data-state="done"]   { background: var(--success); }
+.meter-segment[data-state="active"] {
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  box-shadow: 0 0 12px rgba(94, 134, 255, 0.32);
+}
+.meter-segment[data-state="error"]  { background: var(--error); }
+
+/* Timeline: one unified vertical list. Active row expands inline. */
+.timeline {
+  list-style: none;
+  margin: var(--space-4) 0 0;
+  padding: var(--space-3) var(--space-2);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tl-step {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: 8px var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  transition: background var(--dur-fast) var(--ease-standard);
+}
+.tl-step .ico {
+  width: 18px; height: 18px;
+  display: grid; place-items: center;
+  color: var(--text-tertiary);
+  position: relative;
+}
+.tl-step .ico svg { width: 16px; height: 16px; }
+.tl-step .lbl {
+  font-weight: var(--fw-medium);
+  letter-spacing: -0.005em;
+  color: var(--text-primary);
+}
+.tl-step .summary {
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+/* state: pending */
+.tl-step[data-state="pending"]        { color: var(--text-tertiary); }
+.tl-step[data-state="pending"] .lbl   { color: var(--text-secondary); font-weight: var(--fw-regular); }
+.tl-step[data-state="pending"] .ico   { opacity: 0.5; }
+
+/* state: done */
+.tl-step[data-state="done"] .ico {
+  color: var(--success);
+}
+.tl-step[data-state="done"] .ico::after {
+  /* small inset check overlay */
+  content: "";
+  position: absolute;
+  inset: 0;
+  display: none;  /* keep the SVG glyph; checkmark column shows separately */
+}
+.tl-step[data-state="done"] .check {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--success);
+  color: white;
+  display: inline-grid; place-items: center;
+  font-size: 10px;
+  margin-right: 6px;
+  flex: 0 0 auto;
+}
+
+/* state: error */
+.tl-step[data-state="error"] .ico { color: var(--error); }
+.tl-step[data-state="error"] .lbl { color: var(--error); }
+
+/* state: active */
+.tl-step[data-state="active"] {
+  background: linear-gradient(180deg, rgba(94, 134, 255, 0.10), rgba(94, 134, 255, 0.04));
+  border: 1px solid rgba(94, 134, 255, 0.20);
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  grid-template-rows: auto auto auto;
+  gap: 2px var(--space-3);
+  padding: var(--space-3) var(--space-3);
+  margin: 4px 0;
+}
+.tl-step[data-state="active"] .ico {
+  grid-row: 1 / span 3;
+  align-self: flex-start;
+  color: var(--accent);
+  width: 28px; height: 28px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  margin-top: 2px;
+}
+.tl-step[data-state="active"] .ico svg { width: 18px; height: 18px; }
+.tl-step[data-state="active"] .lbl {
+  grid-column: 2;
+  grid-row: 1;
+  color: var(--text-primary);
+  font-size: var(--fs-h2);
+}
+.tl-step[data-state="active"] .subtitle {
+  grid-column: 2;
+  grid-row: 2;
+  color: var(--text-secondary);
+  font-size: var(--fs-small);
+}
+.tl-step[data-state="active"] .live {
+  grid-column: 2;
+  grid-row: 3;
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tl-step[data-state="active"] .live .detail {
+  font-family: var(--font-mono);
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  min-height: 14px;
+}
+.tl-step[data-state="active"] .live .bar {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.tl-step[data-state="active"] .live .bar > span {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  transition: width var(--dur-medium) var(--ease-standard);
+}
+/* shimmer accent on active row */
+.tl-step[data-state="active"] {
+  position: relative;
+  overflow: hidden;
+}
+.tl-step[data-state="active"]::before {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; top: 0; height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(94, 134, 255, 0.5), transparent);
+  animation: shimmer 1800ms linear infinite;
+}
+@keyframes shimmer {
+  from { transform: translateX(-50%); }
+  to   { transform: translateX(50%); }
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.details {
+  margin-top: var(--space-3);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev);
+  overflow: hidden;
+}
+.details summary {
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--fs-small);
+  color: var(--text-secondary);
+}
+.log {
+  max-height: 160px;
+  overflow-y: auto;
+  padding: 0 var(--space-4) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-tiny);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.log .err { color: var(--error); }
+.log .warn { color: var(--warn); }
+
+/* ---------------------- screen: done ---------------------- */
+
+#screen-done { align-items: center; text-align: center; padding-top: var(--space-12); }
+#screen-done .check {
+  width: 76px; height: 76px;
+  margin: 0 auto var(--space-5);
+  border-radius: 50%;
+  background: var(--success-soft);
+  display: grid; place-items: center;
+  position: relative;
+}
+#screen-done .check svg {
+  width: 38px; height: 38px;
+}
+#screen-done .check svg path {
+  stroke-dasharray: 28;
+  stroke-dashoffset: 28;
+  animation: drawcheck 600ms 100ms cubic-bezier(0.2, 0, 0, 1) forwards;
+}
+@keyframes drawcheck { to { stroke-dashoffset: 0; } }
+#screen-done .summary {
+  margin-top: var(--space-2);
+  font-size: var(--fs-body);
+  color: var(--text-secondary);
+  max-width: 480px;
+}
+#screen-done .actions { margin-top: var(--space-6); display: flex; gap: var(--space-3); }
+#screen-done .backups {
+  margin-top: var(--space-6);
+  text-align: left;
+  width: 100%;
+  max-width: 540px;
+  font-size: var(--fs-small);
+}
+#screen-done .backups .h2 { margin-bottom: var(--space-2); }
+#screen-done .backups ul { list-style: none; padding: 0; margin: 0; }
+#screen-done .backups li {
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--fs-tiny);
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-standard);
+  word-break: break-all;
+}
+#screen-done .backups li:hover { background: var(--bg-elev); color: var(--text-primary); }
+
+/* ---------------------- screen: error ---------------------- */
+
+/* ---------------------- screen: backups ---------------------- */
+
+#screen-backups { padding-top: var(--space-6); }
+.backup-group {
+  margin-bottom: var(--space-5);
+}
+.backup-group h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-semibold);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  letter-spacing: -0.005em;
+}
+.backup-group .desc {
+  font-size: var(--fs-tiny);
+  color: var(--text-tertiary);
+  margin: 0 0 var(--space-2);
+}
+.backup-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.backup-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--fs-small);
+}
+.backup-row .ts { color: var(--text-primary); }
+.backup-row .size {
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.backup-row .btn-pill { font-family: var(--font-text); }
+.backup-row .btn-danger:hover { background: var(--error); color: white; }
+
+#screen-error .icon {
+  width: 56px; height: 56px;
+  margin-bottom: var(--space-5);
+  border-radius: 50%;
+  background: var(--error-soft);
+  display: grid; place-items: center;
+  font-size: 28px;
+  color: var(--error);
+}
+#screen-error .body {
+  margin-top: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-elev);
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--fs-tiny);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  max-height: 220px;
+  overflow-y: auto;
+}

--- a/app/frontend/styles.css
+++ b/app/frontend/styles.css
@@ -402,25 +402,54 @@ body[data-platform="mac"] main {
   gap: var(--space-3);
 }
 .space-row {
+  --space-tint-r: 255;
+  --space-tint-g: 255;
+  --space-tint-b: 255;
+  --space-tint: rgba(var(--space-tint-r), var(--space-tint-g), var(--space-tint-b), 0.12);
+  --space-tint-strong: rgba(var(--space-tint-r), var(--space-tint-g), var(--space-tint-b), 0.45);
+  --space-edge: rgba(var(--space-tint-r), var(--space-tint-g), var(--space-tint-b), 0.30);
+
+  position: relative;
   display: grid;
   grid-template-columns: 32px 1fr auto;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  background: var(--bg-elev);
-  border: 1px solid var(--bd-soft);
+  /* Leave 4 px on the left for the absolutely-positioned coloured edge. */
+  padding: var(--space-3) var(--space-4) var(--space-3) calc(var(--space-4) + 4px);
+  background:
+    linear-gradient(135deg, var(--space-tint) 0%, transparent 70%),
+    var(--bg-elev);
+  border: 1px solid var(--space-edge);
   border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.space-row::before {
+  /* Coloured left edge — absolutely positioned so it spans the full row
+     height regardless of the grid auto-row sizing. */
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  background: var(--space-tint-strong);
 }
 .space-row .icon {
   width: 28px; height: 28px;
   display: grid; place-items: center;
   font-size: 18px;
-  background: var(--bg-elev-hi);
+  background: rgba(var(--space-tint-r), var(--space-tint-g), var(--space-tint-b), 0.22);
   border-radius: var(--radius-sm);
 }
+.space-row .text { min-width: 0; }
 .space-row .name { font-weight: var(--fw-medium); }
 .space-row .meta { font-size: var(--fs-tiny); color: var(--text-tertiary); }
 .space-row .count { font-size: var(--fs-small); color: var(--text-secondary); }
+.space-row.no-color {
+  /* Spaces without an Arc colour fall back to the bare card style. */
+  background: var(--bg-elev);
+  border-color: var(--bd-soft);
+  padding-left: var(--space-4);
+}
+.space-row.no-color::before { display: none; }
 
 .toggles {
   margin-top: var(--space-5);

--- a/app/frontend/tokens.css
+++ b/app/frontend/tokens.css
@@ -1,0 +1,134 @@
+/* ====================================================================
+   Design tokens. Linear/Raycast-flavoured calm dark with a paired light.
+   Mode follows the OS via prefers-color-scheme. Override with
+   <html data-theme="light|dark"> if we ever expose a setting.
+   ==================================================================== */
+
+:root {
+  /* spacing scale (4px base) */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* radii */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+
+  /* type: using Apple system fonts so nothing is bundled */
+  --font-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter",
+                  ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+  --font-text:    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter",
+                  ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+  --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas,
+                  monospace;
+
+  /* type sizes */
+  --fs-display: 28px;
+  --fs-h1: 22px;
+  --fs-h2: 16px;
+  --fs-body: 14px;
+  --fs-small: 12px;
+  --fs-tiny: 11px;
+
+  --fw-regular: 420;
+  --fw-medium: 540;
+  --fw-semibold: 620;
+
+  /* timing */
+  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --ease-standard:  cubic-bezier(0.4, 0, 0.2, 1);
+  --dur-fast: 120ms;
+  --dur-medium: 200ms;
+  --dur-slow: 320ms;
+
+  /* shadows */
+  --shadow-elev1: 0 1px 2px rgba(0, 0, 0, 0.18), 0 4px 16px rgba(0, 0, 0, 0.22);
+  --shadow-elev2: 0 8px 28px rgba(0, 0, 0, 0.32);
+  --shadow-focus: 0 0 0 3px rgba(94, 134, 255, 0.28);
+}
+
+/* ---- dark (default) ---- */
+:root {
+  --bg-base: #0E0F12;
+  --bg-vibrancy: rgba(14, 15, 18, 0.72);  /* over the WKWebView vibrancy */
+  --bg-elev: #15171B;
+  --bg-elev-hi: #1A1D22;
+  --bg-elev-press: #11131642;
+  --bg-overlay: rgba(0, 0, 0, 0.36);
+
+  --bd-soft: rgba(255, 255, 255, 0.06);
+  --bd-medium: rgba(255, 255, 255, 0.10);
+  --bd-strong: rgba(255, 255, 255, 0.16);
+
+  --text-primary: #F5F6F8;
+  --text-secondary: #9AA1AB;
+  --text-tertiary: #6B7280;
+  --text-on-accent: #FFFFFF;
+
+  --accent: #5E86FF;
+  --accent-hover: #6E92FF;
+  --accent-press: #4F76EE;
+  --accent-soft: rgba(94, 134, 255, 0.12);
+
+  --success: #3DD68C;
+  --success-soft: rgba(61, 214, 140, 0.14);
+  --warn: #F4B851;
+  --warn-soft: rgba(244, 184, 81, 0.14);
+  --error: #FF6B6B;
+  --error-soft: rgba(255, 107, 107, 0.14);
+
+  --tl-close: #FF5F57;
+  --tl-min:   #FEBC2E;
+  --tl-max:   #28C840;
+  --tl-idle:  rgba(255, 255, 255, 0.18);
+}
+
+/* ---- light ---- */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg-base: #F4F5F7;
+    --bg-vibrancy: rgba(248, 249, 251, 0.78);
+    --bg-elev: #FFFFFF;
+    --bg-elev-hi: #FFFFFF;
+    --bg-elev-press: #00000008;
+    --bg-overlay: rgba(0, 0, 0, 0.18);
+
+    --bd-soft: rgba(15, 17, 21, 0.06);
+    --bd-medium: rgba(15, 17, 21, 0.10);
+    --bd-strong: rgba(15, 17, 21, 0.18);
+
+    --text-primary: #0F1115;
+    --text-secondary: #5D6470;
+    --text-tertiary: #8A93A0;
+    --text-on-accent: #FFFFFF;
+
+    --accent: #3D67F0;
+    --accent-hover: #4F77FF;
+    --accent-press: #2D58D9;
+    --accent-soft: rgba(61, 103, 240, 0.10);
+
+    --success: #1D9F62;
+    --success-soft: rgba(29, 159, 98, 0.12);
+    --warn: #C7821B;
+    --warn-soft: rgba(199, 130, 27, 0.12);
+    --error: #D63C3C;
+    --error-soft: rgba(214, 60, 60, 0.10);
+
+    --tl-close: #FF5F57;
+    --tl-min:   #FEBC2E;
+    --tl-max:   #28C840;
+    --tl-idle:  rgba(0, 0, 0, 0.10);
+
+    --shadow-elev1: 0 1px 2px rgba(0, 0, 0, 0.06), 0 4px 14px rgba(0, 0, 0, 0.06);
+    --shadow-elev2: 0 8px 24px rgba(0, 0, 0, 0.10);
+  }
+}

--- a/app/frontend/tokens.css
+++ b/app/frontend/tokens.css
@@ -23,11 +23,14 @@
   --radius-lg: 14px;
   --radius-xl: 20px;
 
-  /* type: using Apple system fonts so nothing is bundled */
+  /* Segoe UI deliberately precedes ``system-ui`` so older WebView2 builds
+     on Windows 10 don't fall back to Microsoft Sans Serif when the
+     ``system-ui`` keyword resolves there. macOS resolves the
+     ``-apple-system`` / ``BlinkMacSystemFont`` keywords ahead of the rest. */
   --font-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter",
-                  ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+                  "Segoe UI", system-ui, ui-sans-serif, sans-serif;
   --font-text:    -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter",
-                  ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+                  "Segoe UI", system-ui, ui-sans-serif, sans-serif;
   --font-mono:    ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas,
                   monospace;
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -93,22 +93,20 @@ GUI_STEPS = (
     "sessions",
     "bookmarks",
     "favicons",
-    "open_tabs",
     "history",
     "cookies",
     "finalize",
 )
 
 STEP_LABELS = {
-    "extract":   "Reading Arc data",
+    "extract":    "Reading Arc data",
     "containers": "Creating containers",
-    "sessions":  "Importing spaces, pinned tabs and folders",
-    "bookmarks": "Backing up as bookmarks",
-    "favicons":  "Importing favicons",
-    "open_tabs": "Importing open tabs",
-    "history":   "Importing browsing history",
-    "cookies":   "Importing cookies",
-    "finalize":  "Finalizing",
+    "sessions":   "Importing spaces, pinned tabs, open tabs and folders",
+    "bookmarks":  "Backing up as bookmarks",
+    "favicons":   "Importing favicons",
+    "history":    "Importing browsing history",
+    "cookies":    "Importing cookies",
+    "finalize":   "Finalizing",
 }
 
 
@@ -345,9 +343,29 @@ class MigrationOrchestrator:
         if opts.include_pinned_tabs or opts.include_workspaces:
             self._start_step("sessions")
             try:
+                # ``include_open_tabs`` controls whether Arc's currently-open
+                # (non-pinned) tabs come along too. They go into the same
+                # zen-sessions.jsonlz4 the pinned tabs do — modern Zen reads
+                # both from there, regardless of pinned/unpinned status.
+                # Filter them out of the data fed to the importer when the
+                # toggle is off so we don't have to plumb a flag through.
+                payload = arc_export_data
+                if not opts.include_open_tabs:
+                    payload = dict(arc_export_data)
+                    payload["spaces"] = [
+                        {**sp, "open_tabs": []}
+                        for sp in arc_export_data.get("spaces", [])
+                    ]
+
                 sess = ZenSessionsImporter(zen_profile, folders_collapsed=opts.folders_collapsed)
-                ok = sess.import_arc_data(arc_export_data, container_mappings, dry_run=False)
-                self._done_step("sessions", summary={"ok": bool(ok)})
+                ok = sess.import_arc_data(payload, container_mappings, dry_run=False)
+                pinned_total = sum(len(sp.get("pinned_tabs") or [])
+                                   for sp in payload.get("spaces", []))
+                open_total = sum(len(sp.get("open_tabs") or [])
+                                 for sp in payload.get("spaces", []))
+                self._done_step("sessions", summary={
+                    "ok": bool(ok), "pinned": pinned_total, "open": open_total,
+                })
             except Exception as exc:
                 self._error_step("sessions", exc)
             yield from self._drain_yield()
@@ -378,17 +396,12 @@ class MigrationOrchestrator:
                 self._error_step("favicons", exc)
             yield from self._drain_yield()
 
-        # 6: open tabs (sessionstore) -----------------------------------
-        if opts.include_open_tabs:
-            self._start_step("open_tabs")
-            try:
-                from zen_sessionstore_manager import ZenSessionstoreManager
-                ss = ZenSessionstoreManager(zen_profile)
-                ok = ss.create_workspaces_with_tabs(arc_export_data, container_mappings, dry_run=False)
-                self._done_step("open_tabs", summary={"ok": bool(ok)})
-            except Exception as exc:
-                self._error_step("open_tabs", exc)
-            yield from self._drain_yield()
+        # Open tabs are now part of the "sessions" step above (they go
+        # into zen-sessions.jsonlz4 alongside pinned tabs, which is where
+        # modern Zen actually reads them from). The legacy
+        # ZenSessionstoreManager that used to write to sessionstore.jsonlz4
+        # was a no-op because Zen's #restoreWindowData() overwrites the
+        # sessionstore from zen-sessions on every launch.
 
         # 7: history -----------------------------------------------------
         if opts.include_history:

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -20,7 +20,7 @@ import time
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Iterator, Optional
+from typing import Iterable, Iterator, Optional, Tuple
 
 # Make ``src/`` importable when running from the repo root or as a packaged app.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -53,6 +53,10 @@ class SpaceSummary:
     open_count: int
     folder_count: int
     essential_count: int = 0
+    # Arc midTone colour as integer RGB (0-255) so the frontend can tint the
+    # space card background to match the Arc workspace. ``None`` when the
+    # space has no theme set.
+    color: Optional[Tuple[int, int, int]] = None
 
 
 @dataclass(frozen=True)
@@ -139,6 +143,13 @@ class MigrationOrchestrator:
             open_count = len(s.open_tabs or [])
             essential = sum(1 for t in (s.pinned_tabs or []) if getattr(t, "is_essential", False))
             folder_count = len(s.folders or [])
+            color_rgb: Optional[Tuple[int, int, int]] = None
+            if s.color and all(k in s.color for k in ("r", "g", "b")):
+                color_rgb = (
+                    int(round(s.color["r"] * 255)),
+                    int(round(s.color["g"] * 255)),
+                    int(round(s.color["b"] * 255)),
+                )
             space_summaries.append(SpaceSummary(
                 name=s.space_name,
                 icon=s.icon,
@@ -146,6 +157,7 @@ class MigrationOrchestrator:
                 open_count=open_count,
                 folder_count=folder_count,
                 essential_count=essential,
+                color=color_rgb,
             ))
             pinned_total += pinned_count
             open_total += open_count
@@ -460,6 +472,7 @@ def preview_to_dict(report: PreviewReport) -> dict:
                 "openCount": s.open_count,
                 "folderCount": s.folder_count,
                 "essentialCount": s.essential_count,
+                "color": list(s.color) if s.color else None,
             }
             for s in report.spaces
         ],

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,0 +1,463 @@
+"""
+MigrationOrchestrator: the GUI's facade over the existing importer modules.
+
+We import the existing classes from ``src/`` unchanged. The only thing the
+GUI adds on top is structured progress events, an isolation-safe install of
+the ProgressBus around each step, and a couple of cross-cutting concerns
+(detecting previous migrations, computing per-space counts for Preview).
+
+The CLI tool (``migrate_arc_to_zen.py``) keeps working: it does not import
+this module. There are intentionally no changes to ``src/`` here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import tempfile
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+# Make ``src/`` importable when running from the repo root or as a packaged app.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Existing importer modules (unchanged).
+from arc_pinned_tab_extractor import ArcPinnedTabExtractor               # noqa: E402
+from zen_space_importer import ZenSpaceImporter, ZenProfile as _SrcZenProfile  # noqa: E402
+from zen_sessions_importer import ZenSessionsImporter                    # noqa: E402
+from zen_bookmark_importer import ZenBookmarkImporter                    # noqa: E402
+from zen_favicon_importer import FaviconImporter, _iter_pinned_urls      # noqa: E402
+from arc_history_importer import HistoryImporter                          # noqa: E402
+from arc_cookies_importer import CookiesImporter, _discover_user_containers  # noqa: E402
+
+from .env_check import EnvReport, ZenProfile, check_environment
+from .progress_bus import ProgressBus, ProgressEvent
+
+logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ models
+
+@dataclass(frozen=True)
+class SpaceSummary:
+    name: str
+    icon: Optional[str]
+    pinned_count: int
+    open_count: int
+    folder_count: int
+    essential_count: int = 0
+
+
+@dataclass(frozen=True)
+class PreviewReport:
+    spaces: list[SpaceSummary]
+    pinned_total: int
+    open_total: int
+    folder_total: int
+    bookmark_total: int            # pinned + folder tabs (what gets bookmarked)
+    favicon_match_estimate: int    # how many URLs Arc has cached icons for
+    history_rows_estimate: int
+    cookies_estimate: int
+
+
+@dataclass
+class MigrationOptions:
+    zen_profile_path: Path
+    arc_space_filter: Optional[str] = None
+    folders_collapsed: bool = True
+    include_workspaces: bool = True
+    include_pinned_tabs: bool = True
+    include_bookmarks: bool = True
+    include_favicons: bool = True
+    include_open_tabs: bool = False
+    include_history: bool = False
+    include_cookies: bool = False
+
+
+# ----------- step ordering used in the GUI's progress list (left to right) ---
+
+GUI_STEPS = (
+    "extract",
+    "containers",
+    "sessions",
+    "bookmarks",
+    "favicons",
+    "open_tabs",
+    "history",
+    "cookies",
+    "finalize",
+)
+
+STEP_LABELS = {
+    "extract":   "Reading Arc data",
+    "containers": "Creating containers",
+    "sessions":  "Importing spaces, pinned tabs and folders",
+    "bookmarks": "Backing up as bookmarks",
+    "favicons":  "Importing favicons",
+    "open_tabs": "Importing open tabs",
+    "history":   "Importing browsing history",
+    "cookies":   "Importing cookies",
+    "finalize":  "Finalizing",
+}
+
+
+# ------------------------------------------------------------------ orchestrator
+
+class MigrationOrchestrator:
+    def __init__(self) -> None:
+        self.bus = ProgressBus()
+
+    # ---- env / preview --------------------------------------------------
+
+    def check_environment(self) -> EnvReport:
+        return check_environment()
+
+    def preview(self, opts: MigrationOptions) -> PreviewReport:
+        # Read-only: no bus, no temp files left behind.
+        extractor = ArcPinnedTabExtractor()
+        spaces = extractor.extract_pinned_tabs() or []
+
+        if opts.arc_space_filter:
+            needle = opts.arc_space_filter.lower()
+            spaces = [s for s in spaces if needle in s.space_name.lower()]
+
+        # ``ArcSpace.pinned_tabs`` is the flat list (folder membership is
+        # tracked via ``ArcFolder.children_ids``, not nested children).
+        space_summaries: list[SpaceSummary] = []
+        pinned_total = open_total = folder_total = bookmark_total = 0
+        all_urls: list[str] = []
+
+        for s in spaces:
+            pinned_count = len(s.pinned_tabs or [])
+            open_count = len(s.open_tabs or [])
+            essential = sum(1 for t in (s.pinned_tabs or []) if getattr(t, "is_essential", False))
+            folder_count = len(s.folders or [])
+            space_summaries.append(SpaceSummary(
+                name=s.space_name,
+                icon=s.icon,
+                pinned_count=pinned_count,
+                open_count=open_count,
+                folder_count=folder_count,
+                essential_count=essential,
+            ))
+            pinned_total += pinned_count
+            open_total += open_count
+            folder_total += folder_count
+            bookmark_total += pinned_count
+            for t in (s.pinned_tabs or []):
+                if t.url:
+                    all_urls.append(t.url)
+            for t in (s.open_tabs or []):
+                if t.url:
+                    all_urls.append(t.url)
+
+        # Cheap estimates for the heavy steps. Real counts emerge during the
+        # run; the Preview screen just uses these for UX.
+        favicon_match_estimate = self._estimate_favicons(all_urls)
+        history_rows_estimate = self._estimate_history_rows()
+        cookies_estimate = self._estimate_cookies()
+
+        return PreviewReport(
+            spaces=space_summaries,
+            pinned_total=pinned_total,
+            open_total=open_total,
+            folder_total=folder_total,
+            bookmark_total=bookmark_total,
+            favicon_match_estimate=favicon_match_estimate,
+            history_rows_estimate=history_rows_estimate,
+            cookies_estimate=cookies_estimate,
+        )
+
+    @staticmethod
+    def _estimate_favicons(urls: list[str]) -> int:
+        # Cheapest accurate estimate: count Arc URLs that have a cached icon.
+        try:
+            home = Path.home()
+            arc_root = home / "Library/Application Support/Arc/User Data"
+            if not arc_root.is_dir():
+                return 0
+            import sqlite3
+            unique = set()
+            for db in arc_root.glob("*/Favicons"):
+                try:
+                    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=2.0)
+                    cur = conn.execute("SELECT DISTINCT page_url FROM icon_mapping")
+                    for (page_url,) in cur:
+                        unique.add(page_url)
+                    conn.close()
+                except Exception:
+                    continue
+            return len(unique & set(urls))
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _estimate_history_rows() -> int:
+        try:
+            import sqlite3
+            home = Path.home()
+            root = home / "Library/Application Support/Arc/User Data"
+            total = 0
+            for db in root.glob("*/History"):
+                try:
+                    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=2.0)
+                    n = conn.execute("SELECT COUNT(*) FROM urls WHERE url LIKE 'http%' OR url LIKE 'ftp%'").fetchone()[0]
+                    conn.close()
+                    total += int(n or 0)
+                except Exception:
+                    continue
+            return total
+        except Exception:
+            return 0
+
+    @staticmethod
+    def _estimate_cookies() -> int:
+        try:
+            import sqlite3
+            home = Path.home()
+            root = home / "Library/Application Support/Arc/User Data"
+            total = 0
+            for db in root.glob("*/Cookies"):
+                try:
+                    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=2.0)
+                    n = conn.execute("SELECT COUNT(*) FROM cookies").fetchone()[0]
+                    conn.close()
+                    total += int(n or 0)
+                except Exception:
+                    continue
+            return total
+        except Exception:
+            return 0
+
+    # ---- migration ------------------------------------------------------
+
+    def migrate(self, opts: MigrationOptions) -> Iterator[ProgressEvent]:
+        """Run the full migration. Yields events through the bus.
+
+        Designed to be called on a worker thread; the JS bridge polls
+        ``self.bus.drain()`` from its own thread.
+        """
+        self.bus.install()
+        try:
+            yield from self._run(opts)
+        finally:
+            self.bus.uninstall()
+
+    def _emit(self, event: ProgressEvent) -> None:
+        self.bus.push(event)
+
+    def _start_step(self, step: str) -> None:
+        self.bus.set_step(step)
+        self._emit({"kind": "step_start", "step": step,
+                    "message": STEP_LABELS.get(step, step)})
+
+    def _done_step(self, step: str, summary: Optional[dict] = None,
+                   message: Optional[str] = None) -> None:
+        ev: ProgressEvent = {"kind": "step_done", "step": step,
+                             "message": message or f"{STEP_LABELS.get(step, step)} done"}
+        if summary is not None:
+            ev["summary"] = summary
+        self._emit(ev)
+
+    def _error_step(self, step: str, exc: BaseException) -> None:
+        self._emit({
+            "kind": "step_error",
+            "step": step,
+            "message": f"{STEP_LABELS.get(step, step)} failed",
+            "detail": "".join(traceback.format_exception_only(type(exc), exc)).strip(),
+        })
+
+    def _run(self, opts: MigrationOptions) -> Iterator[ProgressEvent]:
+        zen_profile = opts.zen_profile_path
+
+        # 1: extract -----------------------------------------------------
+        self._start_step("extract")
+        extractor = ArcPinnedTabExtractor()
+        spaces = extractor.extract_pinned_tabs()
+        if not spaces:
+            self._error_step("extract", RuntimeError("No Arc data found."))
+            yield from self._drain_yield()
+            return
+        if opts.arc_space_filter:
+            needle = opts.arc_space_filter.lower()
+            spaces = [s for s in spaces if needle in s.space_name.lower()]
+            if not spaces:
+                self._error_step("extract", RuntimeError(f"No Arc space matches '{opts.arc_space_filter}'."))
+                yield from self._drain_yield()
+                return
+
+        # Materialize the JSON shape the existing importers expect.
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as tf:
+            export_path = Path(tf.name)
+        try:
+            extractor.export_to_json(spaces, export_path)
+            with export_path.open(encoding="utf-8") as fh:
+                arc_export_data = json.load(fh)
+        finally:
+            try:
+                export_path.unlink()
+            except OSError:
+                pass
+
+        space_count = len(arc_export_data.get("spaces", []))
+        pinned_count = sum(len(sp.get("pinned_tabs") or []) for sp in arc_export_data.get("spaces", []))
+        self._done_step("extract", summary={
+            "spaces": space_count,
+            "pinned": pinned_count,
+        }, message=f"Read {space_count} Arc spaces")
+        yield from self._drain_yield()
+
+        # 2: containers --------------------------------------------------
+        container_mappings: dict = {}
+        if opts.include_workspaces:
+            self._start_step("containers")
+            try:
+                src_zen = _SrcZenProfile(name=zen_profile.name, path=zen_profile)
+                space_importer = ZenSpaceImporter(src_zen)
+                container_mappings = space_importer.import_arc_spaces_as_containers(
+                    arc_export_data, dry_run=False
+                ) or {}
+                self._done_step("containers", summary={"created_or_reused": len(container_mappings)})
+            except Exception as exc:
+                self._error_step("containers", exc)
+            yield from self._drain_yield()
+
+        # 3: sessions / pinned tabs / folders ----------------------------
+        if opts.include_pinned_tabs or opts.include_workspaces:
+            self._start_step("sessions")
+            try:
+                sess = ZenSessionsImporter(zen_profile, folders_collapsed=opts.folders_collapsed)
+                ok = sess.import_arc_data(arc_export_data, container_mappings, dry_run=False)
+                self._done_step("sessions", summary={"ok": bool(ok)})
+            except Exception as exc:
+                self._error_step("sessions", exc)
+            yield from self._drain_yield()
+
+        # 4: bookmarks ---------------------------------------------------
+        if opts.include_bookmarks:
+            self._start_step("bookmarks")
+            try:
+                bm = ZenBookmarkImporter(zen_profile)
+                ok = bm.import_arc_bookmarks(arc_export_data, dry_run=False)
+                self._done_step("bookmarks", summary={"ok": bool(ok)})
+            except Exception as exc:
+                self._error_step("bookmarks", exc)
+            yield from self._drain_yield()
+
+        # 5: favicons (DB + inline session image) -----------------------
+        if opts.include_favicons:
+            self._start_step("favicons")
+            try:
+                fav = FaviconImporter(zen_profile, dry_run=False)
+                urls = list(dict.fromkeys(_iter_pinned_urls(arc_export_data)))
+                db_summary = fav.import_favicons(urls)
+                session_summary = fav.inject_session_images(urls)
+                self._done_step("favicons", summary={
+                    "db": db_summary, "session": session_summary,
+                })
+            except Exception as exc:
+                self._error_step("favicons", exc)
+            yield from self._drain_yield()
+
+        # 6: open tabs (sessionstore) -----------------------------------
+        if opts.include_open_tabs:
+            self._start_step("open_tabs")
+            try:
+                from zen_sessionstore_manager import ZenSessionstoreManager
+                ss = ZenSessionstoreManager(zen_profile)
+                ok = ss.create_workspaces_with_tabs(arc_export_data, container_mappings, dry_run=False)
+                self._done_step("open_tabs", summary={"ok": bool(ok)})
+            except Exception as exc:
+                self._error_step("open_tabs", exc)
+            yield from self._drain_yield()
+
+        # 7: history -----------------------------------------------------
+        if opts.include_history:
+            self._start_step("history")
+            try:
+                h = HistoryImporter(zen_profile, dry_run=False)
+                summary = h.import_history()
+                self._done_step("history", summary=summary)
+            except Exception as exc:
+                self._error_step("history", exc)
+            yield from self._drain_yield()
+
+        # 8: cookies -----------------------------------------------------
+        if opts.include_cookies:
+            self._start_step("cookies")
+            try:
+                container_ids = _discover_user_containers(zen_profile)
+                c = CookiesImporter(zen_profile, dry_run=False, container_ids=container_ids)
+                summary = c.import_cookies()
+                if summary.get("error"):
+                    err = summary["error"]
+                    msg = {
+                        "keychain_denied":      "macOS Keychain access was denied; cookies skipped.",
+                        "unsupported_platform": "Cookie import is macOS-only.",
+                        "cookies_db_missing":   "Zen cookies.sqlite was not found.",
+                    }.get(err, f"Cookie import failed: {err}")
+                    self._error_step("cookies", RuntimeError(msg))
+                else:
+                    self._done_step("cookies", summary=summary)
+            except Exception as exc:
+                self._error_step("cookies", exc)
+            yield from self._drain_yield()
+
+        # 9: finalize ----------------------------------------------------
+        self._start_step("finalize")
+        try:
+            (zen_profile / ".arc2zen-migrated").write_text(
+                json.dumps({"ts": time.time(), "version": 1}), encoding="utf-8"
+            )
+        except Exception:
+            pass
+        self._done_step("finalize", message="Migration complete")
+        yield from self._drain_yield()
+
+    def _drain_yield(self) -> Iterator[ProgressEvent]:
+        for ev in self.bus.drain():
+            yield ev
+
+    # ---- backups + utility for the Done screen --------------------------
+
+    @staticmethod
+    def find_backups(zen_profile: Path) -> list[Path]:
+        """Backup files we (and the existing importers) leave behind."""
+        if not zen_profile.is_dir():
+            return []
+        out: list[Path] = []
+        out.extend(sorted(zen_profile.glob("*.backup.*")))
+        return out
+
+
+# ----- JSON helpers for the bridge ----------------------------------------
+
+
+def preview_to_dict(report: PreviewReport) -> dict:
+    return {
+        "spaces": [
+            {
+                "name": s.name,
+                "icon": s.icon,
+                "pinnedCount": s.pinned_count,
+                "openCount": s.open_count,
+                "folderCount": s.folder_count,
+                "essentialCount": s.essential_count,
+            }
+            for s in report.spaces
+        ],
+        "pinnedTotal": report.pinned_total,
+        "openTotal": report.open_total,
+        "folderTotal": report.folder_total,
+        "bookmarkTotal": report.bookmark_total,
+        "faviconMatchEstimate": report.favicon_match_estimate,
+        "historyRowsEstimate": report.history_rows_estimate,
+        "cookiesEstimate": report.cookies_estimate,
+    }

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -399,9 +399,19 @@ class MigrationOrchestrator:
                 if summary.get("error"):
                     err = summary["error"]
                     msg = {
-                        "keychain_denied":      "macOS Keychain access was denied; cookies skipped.",
-                        "unsupported_platform": "Cookie import is macOS-only.",
-                        "cookies_db_missing":   "Zen cookies.sqlite was not found.",
+                        # macOS
+                        "keychain_denied":           "macOS Keychain access was denied; cookies skipped.",
+                        # Windows
+                        "arc_local_state_missing":   "Arc has not been launched on this Windows account yet; cookies skipped.",
+                        "arc_no_encrypted_key":      "Arc has no cookie encryption key on this account; cookies skipped.",
+                        "arc_appbound_encryption":   "Arc cookies use newer (v20) app-bound encryption; cookies skipped. Sign in fresh on imported sites.",
+                        "arc_unknown_key_prefix":    "Arc Local State key has an unrecognised prefix; cookies skipped.",
+                        "arc_unexpected_key_length": "Arc DPAPI key has unexpected length; cookies skipped.",
+                        "dpapi_wrong_user":          "Cookies were encrypted on a different Windows account and can't be migrated. Sign in fresh on imported sites.",
+                        "dpapi_failed":              "Windows DPAPI rejected the cookie key; cookies skipped.",
+                        # Both
+                        "unsupported_platform":      "Cookie import only supports macOS and Windows.",
+                        "cookies_db_missing":        "Zen cookies.sqlite was not found.",
                     }.get(err, f"Cookie import failed: {err}")
                     self._error_step("cookies", RuntimeError(msg))
                 else:

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -80,7 +80,7 @@ class MigrationOptions:
     include_pinned_tabs: bool = True
     include_bookmarks: bool = True
     include_favicons: bool = True
-    include_open_tabs: bool = False
+    include_open_tabs: bool = True
     include_history: bool = False
     include_cookies: bool = False
 

--- a/app/progress_bus.py
+++ b/app/progress_bus.py
@@ -1,0 +1,114 @@
+"""
+Structured progress bus for the GUI.
+
+A `logging.Handler` subclass collects log records emitted by the existing
+importer modules (`logger.info(...)` calls) and converts them into
+structured `ProgressEvent` dicts the JavaScript frontend can render.
+
+The orchestrator also `push()`es its own high-level events
+(step_start / step_done / step_error) directly, so the frontend has both:
+- A canonical step list driven by orchestrator events.
+- A free-form "View details" stream of raw log messages.
+
+The frontend drains the queue every 100ms via the JS bridge.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from typing import Any, Literal, Optional, TypedDict
+
+
+class ProgressEvent(TypedDict, total=False):
+    kind: Literal["step_start", "step_progress", "step_done", "step_error", "log", "warn", "info"]
+    step: str
+    percent: Optional[float]   # 0..1, None when indeterminate
+    message: str
+    detail: Optional[str]
+    ts: float
+    summary: Optional[dict]    # populated on step_done with the importer's return dict
+
+
+class ProgressBus(logging.Handler):
+    """Logging handler that records the active step and pushes events to a queue.
+
+    Thread-safe: events from any thread can be pushed; only the JS bridge thread
+    drains. Uses an unbounded queue (~kB per event, finite migration time, fine).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.INFO)
+        self._queue: queue.Queue[ProgressEvent] = queue.Queue()
+        self._step: Optional[str] = None
+        self._lock = threading.Lock()
+
+    # ---- step context ----
+
+    def set_step(self, step: str) -> None:
+        with self._lock:
+            self._step = step
+
+    def current_step(self) -> Optional[str]:
+        with self._lock:
+            return self._step
+
+    # ---- direct push (orchestrator-level events) ----
+
+    def push(self, event: ProgressEvent) -> None:
+        event.setdefault("ts", time.time())
+        if "step" not in event and self._step is not None:
+            event["step"] = self._step
+        self._queue.put(event)
+
+    # ---- logging.Handler interface ----
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            msg = str(record.msg)
+        kind: str
+        if record.levelno >= logging.ERROR:
+            kind = "log"
+        elif record.levelno >= logging.WARNING:
+            kind = "warn"
+        else:
+            kind = "log"
+        event: ProgressEvent = {
+            "kind": kind,  # type: ignore[typeddict-item]
+            "message": msg,
+            "ts": record.created,
+        }
+        if self._step is not None:
+            event["step"] = self._step
+        self._queue.put(event)
+
+    # ---- consumer ----
+
+    def drain(self) -> list[ProgressEvent]:
+        out: list[ProgressEvent] = []
+        try:
+            while True:
+                out.append(self._queue.get_nowait())
+        except queue.Empty:
+            pass
+        return out
+
+    # ---- lifecycle helpers (so the CLI is unaffected when both run in the
+    # same Python process during development) ----
+
+    def install(self, logger_names: tuple[str, ...] = ("",)) -> None:
+        """Attach this handler to the named loggers (root by default)."""
+        for name in logger_names:
+            logging.getLogger(name).addHandler(self)
+            # Make sure INFO records actually reach us
+            target = logging.getLogger(name)
+            if target.level == logging.NOTSET or target.level > logging.INFO:
+                target.setLevel(logging.INFO)
+
+    def uninstall(self, logger_names: tuple[str, ...] = ("",)) -> None:
+        for name in logger_names:
+            logging.getLogger(name).removeHandler(self)

--- a/app/window.py
+++ b/app/window.py
@@ -61,6 +61,27 @@ def launch(debug: bool = False) -> None:
     )
     bridge.set_window(window)
 
+    # Inject the canonical version straight into the DOM as soon as the page
+    # finishes loading. Doing this here (rather than relying on a JS-bridge
+    # call from app.js) sidesteps any race between ``pywebviewready`` firing
+    # and ``window.pywebview.api`` being populated.
+    from .__version__ import VERSION
+
+    def _on_loaded() -> None:
+        try:
+            window.evaluate_js(
+                "(() => {"
+                f"  const v = {VERSION!r};"
+                "   document.body.dataset.appVersion = v;"
+                "   const node = document.getElementById('ver');"
+                "   if (node) node.textContent = 'arc2zen · v' + v;"
+                "})();"
+            )
+        except Exception as exc:
+            logger.warning(f"version injection failed: {exc}")
+
+    window.events.loaded += _on_loaded
+
     webview.start(
         debug=debug,
         private_mode=False,

--- a/app/window.py
+++ b/app/window.py
@@ -1,0 +1,64 @@
+"""
+PyWebView window setup.
+
+Single 760×580 frameless window, vibrancy on macOS for the modern translucent
+chrome. Frontend assets are served by pywebview's built-in HTTP server so we
+avoid WKWebView's local-file restrictions.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import webview
+
+from .bridge import Bridge
+
+logger = logging.getLogger(__name__)
+
+
+def _frontend_dir() -> Path:
+    """Find the bundled frontend assets, both in dev and PyInstaller modes."""
+    here = Path(__file__).resolve().parent / "frontend"
+    if here.is_dir():
+        return here
+    # PyInstaller --onedir: assets are next to the binary in Contents/Resources.
+    if hasattr(sys, "_MEIPASS"):
+        bundled = Path(sys._MEIPASS) / "app" / "frontend"
+        if bundled.is_dir():
+            return bundled
+    raise RuntimeError(f"Frontend directory not found (tried {here})")
+
+
+def launch(debug: bool = False) -> None:
+    bridge = Bridge()
+
+    frontend = _frontend_dir()
+    # Use a file:// URL (simpler and avoids the bottle HTTP server thread).
+    # We don't need cross-origin fetches; everything goes through the JS bridge.
+    entry = (frontend / "index.html").as_uri()
+
+    window = webview.create_window(
+        title="Arc2Zen",
+        url=entry,
+        js_api=bridge,
+        width=760,
+        height=580,
+        min_size=(760, 580),
+        resizable=False,
+        frameless=True,
+        # easy_drag=True enables Cocoa's `mouseDownCanMoveWindow`, letting users
+        # drag the window from any non-interactive area while buttons still work.
+        # CSS `-webkit-app-region: drag` is not honoured by WKWebView.
+        easy_drag=True,
+        background_color="#0E0F12",
+        vibrancy=(sys.platform == "darwin"),
+    )
+    bridge.set_window(window)
+
+    webview.start(
+        debug=debug,
+        private_mode=False,
+    )

--- a/app/window.py
+++ b/app/window.py
@@ -40,6 +40,8 @@ def launch(debug: bool = False) -> None:
     # We don't need cross-origin fetches; everything goes through the JS bridge.
     entry = (frontend / "index.html").as_uri()
 
+    is_mac = sys.platform == "darwin"
+
     window = webview.create_window(
         title="Arc2Zen",
         url=entry,
@@ -48,13 +50,14 @@ def launch(debug: bool = False) -> None:
         height=580,
         min_size=(760, 580),
         resizable=False,
-        frameless=True,
-        # easy_drag=True enables Cocoa's `mouseDownCanMoveWindow`, letting users
-        # drag the window from any non-interactive area while buttons still work.
-        # CSS `-webkit-app-region: drag` is not honoured by WKWebView.
-        easy_drag=True,
+        # macOS: frameless window with vibrancy and our custom titlebar /
+        # traffic lights. Windows: keep the OS-native title bar so we get
+        # snap zones, Aero shake, multi-monitor DPI handling, and the
+        # platform-correct close/minimize/maximize buttons for free.
+        frameless=is_mac,
+        easy_drag=is_mac,
         background_color="#0E0F12",
-        vibrancy=(sys.platform == "darwin"),
+        vibrancy=is_mac,
     )
     bridge.set_window(window)
 

--- a/build/INSTRUCTIONS.txt
+++ b/build/INSTRUCTIONS.txt
@@ -1,24 +1,26 @@
-Arc2Zen — first launch on macOS
-================================
+Arc2Zen — first launch
+=======================
 
-macOS will block Arc2Zen the very first time you open it because the
-app isn't notarized by Apple. This is a one-time setup you need to do.
-Follow these steps EXACTLY:
+Arc2Zen is unsigned (no $99/year Apple or Microsoft developer
+certificate), so the first time you open it the OS will block it. This
+is a one-time setup. Follow the steps for your platform exactly.
 
-  Step 1.  Double-click Arc2Zen.app inside this DMG.
+
+------ macOS ----------------------------------------------------------
+
+  Step 1.  Double-click Arc2Zen.app inside the mounted DMG.
 
   Step 2.  macOS shows a dialog: "'Arc2Zen' is damaged and can't be
            opened" or "Apple cannot check it for malicious software."
            Click "Done" (or "Cancel"). DO NOT click "Move to Trash."
 
-  Step 3.  Open System Settings (the gear icon in your Dock, or  → System Settings).
+  Step 3.  Open System Settings (the gear icon in your Dock, or
+            > System Settings).
 
   Step 4.  In the sidebar, scroll down and click "Privacy & Security."
 
   Step 5.  Scroll down on the right side until you see this message:
-
              "Arc2Zen was blocked to protect your Mac."
-
            Click the "Open Anyway" button next to it.
 
   Step 6.  macOS asks for your Mac password — enter it.
@@ -27,24 +29,53 @@ Follow these steps EXACTLY:
            of 'Arc2Zen'. Are you sure you want to open it?"
            Click "Open Anyway".
 
-The app launches.
+The app launches. After this you can double-click Arc2Zen.app any time
+without going through the steps again.
 
-After this, you can double-click Arc2Zen.app any time without going
-through these steps again — macOS only blocks the first launch.
 
-----------------------------------------------------------------------
+------ Windows --------------------------------------------------------
 
-Why all these steps?
+BEFORE EXTRACTING the .zip, do this once:
 
-Apple charges $99 per year for the developer certificate that would
-remove this prompt. Arc2Zen is free open-source software and that fee
-isn't worth passing on. The app is ad-hoc codesigned so its contents
-have not been tampered with — verify any time with:
+  Step 1.  Right-click the downloaded Arc2Zen-*.zip in your Downloads
+           folder and choose "Properties."
+
+  Step 2.  At the bottom of the Properties dialog you'll see "Security:
+           This file came from another computer..." with an "Unblock"
+           checkbox. Tick it and click OK.
+
+  (This strips the "Mark of the Web" tag from every file inside the
+  zip in one shot. If you skip this step, every individual .dll inside
+  Arc2Zen will trip SmartScreen separately.)
+
+THEN extract and run:
+
+  Step 3.  Double-click the .zip and drag the Arc2Zen folder to your
+           Desktop (or wherever you want).
+
+  Step 4.  Open the Arc2Zen folder and double-click Arc2Zen.exe.
+
+  Step 5.  Windows shows "Windows protected your PC" with a Don't Run
+           button. Click "More info" (small text under the title).
+
+  Step 6.  A "Run anyway" button appears. Click it.
+
+The app launches. When you're done with the migration, drag the
+Arc2Zen folder to the Recycle Bin. There's nothing to uninstall.
+
+
+------ Why all these steps? ------------------------------------------
+
+Apple and Microsoft both charge developers for certificates that
+remove these prompts. Arc2Zen is free open-source software and those
+fees aren't worth passing on to users.
+
+The macOS bundle is ad-hoc codesigned, so you can verify its contents
+have not been tampered with at any time:
 
   codesign --verify --deep --strict /Volumes/Arc2Zen/Arc2Zen.app
 
-Source code: https://github.com/tarikbc/arc2zen
+Both platforms are reproducible from source: see the build/ scripts
+in the repository.
 
-When you're done with the migration, drag the DMG to the Trash. There
-is nothing else to clean up — Arc2Zen runs from the DMG and doesn't
-install itself anywhere.
+Source code: https://github.com/rafcabezas/arc2zen

--- a/build/INSTRUCTIONS.txt
+++ b/build/INSTRUCTIONS.txt
@@ -1,0 +1,50 @@
+Arc2Zen — first launch on macOS
+================================
+
+macOS will block Arc2Zen the very first time you open it because the
+app isn't notarized by Apple. This is a one-time setup you need to do.
+Follow these steps EXACTLY:
+
+  Step 1.  Double-click Arc2Zen.app inside this DMG.
+
+  Step 2.  macOS shows a dialog: "'Arc2Zen' is damaged and can't be
+           opened" or "Apple cannot check it for malicious software."
+           Click "Done" (or "Cancel"). DO NOT click "Move to Trash."
+
+  Step 3.  Open System Settings (the gear icon in your Dock, or  → System Settings).
+
+  Step 4.  In the sidebar, scroll down and click "Privacy & Security."
+
+  Step 5.  Scroll down on the right side until you see this message:
+
+             "Arc2Zen was blocked to protect your Mac."
+
+           Click the "Open Anyway" button next to it.
+
+  Step 6.  macOS asks for your Mac password — enter it.
+
+  Step 7.  Another dialog appears: "macOS cannot verify the developer
+           of 'Arc2Zen'. Are you sure you want to open it?"
+           Click "Open Anyway".
+
+The app launches.
+
+After this, you can double-click Arc2Zen.app any time without going
+through these steps again — macOS only blocks the first launch.
+
+----------------------------------------------------------------------
+
+Why all these steps?
+
+Apple charges $99 per year for the developer certificate that would
+remove this prompt. Arc2Zen is free open-source software and that fee
+isn't worth passing on. The app is ad-hoc codesigned so its contents
+have not been tampered with — verify any time with:
+
+  codesign --verify --deep --strict /Volumes/Arc2Zen/Arc2Zen.app
+
+Source code: https://github.com/tarikbc/arc2zen
+
+When you're done with the migration, drag the DMG to the Trash. There
+is nothing else to clean up — Arc2Zen runs from the DMG and doesn't
+install itself anywhere.

--- a/build/arc2zen.spec
+++ b/build/arc2zen.spec
@@ -1,10 +1,11 @@
-# PyInstaller spec for the Arc2Zen GUI app.
+# PyInstaller spec for the Arc2Zen GUI app — macOS and Windows.
 #
 # Run from the repo root:
 #   pyinstaller build/arc2zen.spec
 #
-# Produces dist/Arc2Zen.app (arm64). The build script then ad-hoc signs it
-# and packages it into a .dmg via create-dmg.
+# Produces dist/Arc2Zen.app (macOS arm64) or dist/Arc2Zen/ (Windows x64).
+# The platform-specific build scripts (build/make_app.sh, build/make_exe.ps1)
+# wrap this and produce the final distributable artifact.
 
 # noqa: E402  (Analysis/PYZ/EXE/COLLECT/BUNDLE are injected by PyInstaller)
 
@@ -14,6 +15,38 @@ from pathlib import Path
 REPO_ROOT = Path.cwd().resolve()
 SRC_DIR = REPO_ROOT / "src"
 APP_DIR = REPO_ROOT / "app"
+
+IS_MAC = sys.platform == "darwin"
+IS_WIN = sys.platform == "win32"
+
+# ---- platform-specific Analysis inputs -----------------------------------
+
+PLATFORM_HIDDEN_IMPORTS = (
+    [
+        "webview.platforms.cocoa",
+        "objc",
+        "Foundation",
+        "AppKit",
+        "WebKit",
+    ]
+    if IS_MAC
+    else [
+        # WebView2 backend on Windows. pywebview lazy-imports these via
+        # ``webview/platforms/edgechromium.py``; PyInstaller's static
+        # analysis doesn't see them without a hint.
+        "webview.platforms.edgechromium",
+        "webview.platforms.winforms",
+        "clr_loader",
+        "pythonnet",
+    ]
+)
+
+ICON_NAME = "icon.icns" if IS_MAC else "icon.ico"
+PLATFORM_ICON = str(APP_DIR / "assets" / ICON_NAME)
+
+# Don't pin ``target_arch`` on Windows: PyInstaller picks the host arch
+# correctly. Pinning would break if/when GitHub moves to ARM64 runners.
+TARGET_ARCH = "arm64" if IS_MAC else None
 
 block_cipher = None
 
@@ -31,9 +64,10 @@ a = Analysis(
         "lz4", "lz4.block",
         "cryptography",
         "cryptography.hazmat.primitives.ciphers",
+        "cryptography.hazmat.primitives.ciphers.aead",
         "cryptography.hazmat.primitives.kdf.pbkdf2",
-        "webview", "webview.platforms.cocoa",
-        "objc", "Foundation", "AppKit", "WebKit",
+        "webview",
+        *PLATFORM_HIDDEN_IMPORTS,
         "arc_pinned_tab_extractor",
         "zen_space_importer",
         "zen_sessions_importer",
@@ -69,10 +103,10 @@ exe = EXE(
     upx=False,
     console=False,
     disable_windowed_traceback=False,
-    target_arch="arm64",
+    target_arch=TARGET_ARCH,
     codesign_identity=None,
     entitlements_file=None,
-    icon=str(APP_DIR / "assets" / "icon.icns"),
+    icon=PLATFORM_ICON,
 )
 
 coll = COLLECT(
@@ -85,25 +119,26 @@ coll = COLLECT(
     name="Arc2Zen",
 )
 
-app = BUNDLE(
-    coll,
-    name="Arc2Zen.app",
-    icon=str(APP_DIR / "assets" / "icon.icns"),
-    bundle_identifier="com.tarikbc.arc2zen",
-    version="1.0.0",
-    info_plist={
-        "CFBundleName": "Arc2Zen",
-        "CFBundleDisplayName": "Arc2Zen",
-        "CFBundleVersion": "1.0.0",
-        "CFBundleShortVersionString": "1.0.0",
-        "NSHighResolutionCapable": True,
-        "NSRequiresAquaSystemAppearance": False,
-        "LSApplicationCategoryType": "public.app-category.utilities",
-        "LSMinimumSystemVersion": "12.0",
-        "NSSupportsAutomaticTermination": True,
-        # Reading the macOS Keychain to decrypt Arc cookies needs an
-        # explanation string the first time the user is prompted.
-        "NSDesktopFolderUsageDescription":
-            "Arc2Zen reads Arc cookies from your library to migrate login state.",
-    },
-)
+# BUNDLE() produces a .app on macOS only. On Windows the COLLECT() output
+# directory is itself the ship artifact.
+if IS_MAC:
+    app = BUNDLE(
+        coll,
+        name="Arc2Zen.app",
+        icon=PLATFORM_ICON,
+        bundle_identifier="com.arc2zen.app",
+        version="1.0.0",
+        info_plist={
+            "CFBundleName": "Arc2Zen",
+            "CFBundleDisplayName": "Arc2Zen",
+            "CFBundleVersion": "1.0.0",
+            "CFBundleShortVersionString": "1.0.0",
+            "NSHighResolutionCapable": True,
+            "NSRequiresAquaSystemAppearance": False,
+            "LSApplicationCategoryType": "public.app-category.utilities",
+            "LSMinimumSystemVersion": "12.0",
+            "NSSupportsAutomaticTermination": True,
+            "NSDesktopFolderUsageDescription":
+                "Arc2Zen reads Arc cookies from your library to migrate login state.",
+        },
+    )

--- a/build/arc2zen.spec
+++ b/build/arc2zen.spec
@@ -1,0 +1,109 @@
+# PyInstaller spec for the Arc2Zen GUI app.
+#
+# Run from the repo root:
+#   pyinstaller build/arc2zen.spec
+#
+# Produces dist/Arc2Zen.app (arm64). The build script then ad-hoc signs it
+# and packages it into a .dmg via create-dmg.
+
+# noqa: E402  (Analysis/PYZ/EXE/COLLECT/BUNDLE are injected by PyInstaller)
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path.cwd().resolve()
+SRC_DIR = REPO_ROOT / "src"
+APP_DIR = REPO_ROOT / "app"
+
+block_cipher = None
+
+a = Analysis(
+    [str(REPO_ROOT / "build" / "run_app.py")],
+    pathex=[str(REPO_ROOT), str(SRC_DIR)],
+    binaries=[],
+    datas=[
+        (str(APP_DIR / "frontend"), "app/frontend"),
+        (str(APP_DIR / "assets"),   "app/assets"),
+    ],
+    # Importers in src/ are loaded via sys.path manipulation in
+    # app/orchestrator.py, so PyInstaller can't see them statically.
+    hiddenimports=[
+        "lz4", "lz4.block",
+        "cryptography",
+        "cryptography.hazmat.primitives.ciphers",
+        "cryptography.hazmat.primitives.kdf.pbkdf2",
+        "webview", "webview.platforms.cocoa",
+        "objc", "Foundation", "AppKit", "WebKit",
+        "arc_pinned_tab_extractor",
+        "zen_space_importer",
+        "zen_sessions_importer",
+        "zen_bookmark_importer",
+        "zen_favicon_importer",
+        "zen_pinned_tab_importer",
+        "zen_workspace_importer",
+        "zen_sessionstore_manager",
+        "arc_history_importer",
+        "arc_cookies_importer",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Arc2Zen",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch="arm64",
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=str(APP_DIR / "assets" / "icon.icns"),
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="Arc2Zen",
+)
+
+app = BUNDLE(
+    coll,
+    name="Arc2Zen.app",
+    icon=str(APP_DIR / "assets" / "icon.icns"),
+    bundle_identifier="com.tarikbc.arc2zen",
+    version="1.0.0",
+    info_plist={
+        "CFBundleName": "Arc2Zen",
+        "CFBundleDisplayName": "Arc2Zen",
+        "CFBundleVersion": "1.0.0",
+        "CFBundleShortVersionString": "1.0.0",
+        "NSHighResolutionCapable": True,
+        "NSRequiresAquaSystemAppearance": False,
+        "LSApplicationCategoryType": "public.app-category.utilities",
+        "LSMinimumSystemVersion": "12.0",
+        "NSSupportsAutomaticTermination": True,
+        # Reading the macOS Keychain to decrypt Arc cookies needs an
+        # explanation string the first time the user is prompted.
+        "NSDesktopFolderUsageDescription":
+            "Arc2Zen reads Arc cookies from your library to migrate login state.",
+    },
+)

--- a/build/arc2zen.spec
+++ b/build/arc2zen.spec
@@ -16,6 +16,15 @@ REPO_ROOT = Path.cwd().resolve()
 SRC_DIR = REPO_ROOT / "src"
 APP_DIR = REPO_ROOT / "app"
 
+# Single source of truth for the version string. Read app/__version__.py
+# at spec evaluation time so the bundled Info.plist (macOS) / file version
+# block (Windows) and the runtime ``bridge.version()`` always agree.
+_version_globals: dict = {}
+exec(compile((APP_DIR / "__version__.py").read_text(encoding="utf-8"),
+             str(APP_DIR / "__version__.py"), "exec"),
+     _version_globals)
+VERSION = _version_globals["VERSION"]
+
 IS_MAC = sys.platform == "darwin"
 IS_WIN = sys.platform == "win32"
 
@@ -127,12 +136,12 @@ if IS_MAC:
         name="Arc2Zen.app",
         icon=PLATFORM_ICON,
         bundle_identifier="com.arc2zen.app",
-        version="1.0.0",
+        version=VERSION,
         info_plist={
             "CFBundleName": "Arc2Zen",
             "CFBundleDisplayName": "Arc2Zen",
-            "CFBundleVersion": "1.0.0",
-            "CFBundleShortVersionString": "1.0.0",
+            "CFBundleVersion": VERSION,
+            "CFBundleShortVersionString": VERSION,
             "NSHighResolutionCapable": True,
             "NSRequiresAquaSystemAppearance": False,
             "LSApplicationCategoryType": "public.app-category.utilities",

--- a/build/make_app.sh
+++ b/build/make_app.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build dist/Arc2Zen.app from app/ + src/ + the PyInstaller spec, then
+# ad-hoc codesign the bundle. Outputs a runnable .app — no .dmg yet
+# (see make_dmg.sh for that step).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# 1. Render the app icon if it isn't on disk yet (`.icns` is gitignored).
+[[ -f app/assets/icon.icns ]] || bash build/make_iconset.sh
+
+# 2. PyInstaller. --clean nukes any cached state from a prior failed run.
+echo "==> pyinstaller"
+pyinstaller --noconfirm --clean build/arc2zen.spec
+
+# 3. Ad-hoc codesign every bundled binary so Gatekeeper doesn't flag the
+# app as "damaged" (which it does for unsigned PyInstaller bundles
+# whose embedded dylibs lose their original signatures during reassembly).
+echo "==> codesign --deep --sign -"
+codesign --force --deep --sign - "dist/Arc2Zen.app"
+
+# 4. Verify.
+codesign --verify --deep --strict --verbose=2 "dist/Arc2Zen.app" 2>&1 | tail -3 || {
+  echo "codesign verification failed" >&2
+  exit 1
+}
+
+echo "==> done: dist/Arc2Zen.app"
+ls -lah dist/Arc2Zen.app/Contents/MacOS/

--- a/build/make_dmg.sh
+++ b/build/make_dmg.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Package dist/Arc2Zen.app into a .dmg with a "drag to Applications" layout
+# and an INSTRUCTIONS.txt the user sees inside the mounted volume.
+#
+# Uses hdiutil only (ships with macOS, no extra dependencies).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="${VERSION:-1.0.0}"
+DMG_NAME="Arc2Zen-${VERSION}-arm64.dmg"
+VOLNAME="Arc2Zen"
+
+[[ -d dist/Arc2Zen.app ]] || { echo "dist/Arc2Zen.app not found. Run build/make_app.sh first." >&2; exit 1; }
+
+# Stage the .app + Applications shortcut + INSTRUCTIONS.txt into a clean
+# directory so the mounted volume has only the things we want visible.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+cp -R "dist/Arc2Zen.app" "$STAGE/"
+# Arc2Zen is run-once-and-trash software, so we don't ship the
+# usual "Applications" symlink. Users double-click the app inside
+# the mounted DMG, run the migration, then drag the DMG to Trash.
+[[ -f build/INSTRUCTIONS.txt ]] && cp build/INSTRUCTIONS.txt "$STAGE/"
+
+# Strip xattrs so Finder doesn't show stale spotlight metadata.
+xattr -cr "$STAGE" 2>/dev/null || true
+
+rm -f "dist/$DMG_NAME"
+
+echo "==> hdiutil create"
+hdiutil create \
+  -volname "$VOLNAME" \
+  -srcfolder "$STAGE" \
+  -fs HFS+ \
+  -format UDZO \
+  -imagekey zlib-level=9 \
+  -ov \
+  "dist/$DMG_NAME" >/dev/null
+
+# Verify the image opens cleanly.
+echo "==> hdiutil verify"
+hdiutil verify "dist/$DMG_NAME" >/dev/null
+
+echo "==> done: dist/$DMG_NAME ($(du -h "dist/$DMG_NAME" | cut -f1))"

--- a/build/make_exe.ps1
+++ b/build/make_exe.ps1
@@ -1,0 +1,26 @@
+# Build dist/Arc2Zen/ from app/ + src/ + the PyInstaller spec.
+# Outputs a folder containing Arc2Zen.exe and its _internal/ runtime
+# (the ship artifact). No code-signing.
+$ErrorActionPreference = 'Stop'
+
+$root = Resolve-Path "$PSScriptRoot/.."
+Push-Location $root
+try {
+    if (-not (Test-Path 'app/assets/icon.ico')) {
+        Write-Host '==> generating icon.ico'
+        & pwsh -NoProfile -File 'build/make_iconset.ps1'
+    }
+
+    Write-Host '==> pyinstaller'
+    & pyinstaller --noconfirm --clean 'build/arc2zen.spec'
+    if ($LASTEXITCODE -ne 0) { throw "pyinstaller failed" }
+
+    if (-not (Test-Path 'dist/Arc2Zen/Arc2Zen.exe')) {
+        throw "expected dist/Arc2Zen/Arc2Zen.exe to exist"
+    }
+
+    $size = (Get-ChildItem -Recurse 'dist/Arc2Zen' | Measure-Object -Property Length -Sum).Sum
+    Write-Host ("==> done: dist/Arc2Zen/Arc2Zen.exe ({0:N1} MB unpacked)" -f ($size / 1MB))
+} finally {
+    Pop-Location
+}

--- a/build/make_iconset.ps1
+++ b/build/make_iconset.ps1
@@ -1,0 +1,33 @@
+# Render app/assets/icon.svg into app/assets/icon.ico via ImageMagick.
+# ImageMagick ships preinstalled on the GitHub Actions windows-latest
+# runner. For local builds, install via `winget install ImageMagick.ImageMagick`
+# or `choco install imagemagick`.
+$ErrorActionPreference = 'Stop'
+
+$root = Resolve-Path "$PSScriptRoot/.."
+$svg  = Join-Path $root 'app/assets/icon.svg'
+$ico  = Join-Path $root 'app/assets/icon.ico'
+
+if (-not (Test-Path $svg)) {
+    throw "icon.svg not found at $svg"
+}
+
+# Multi-resolution .ico (16/24/32/48/64/128/256). Windows picks the best
+# size at runtime depending on context (taskbar, alt-tab, file icon).
+$tmp = New-Item -ItemType Directory -Path (Join-Path $env:TEMP "arc2zen-iconset-$([guid]::NewGuid())")
+try {
+    $sizes = 16, 24, 32, 48, 64, 128, 256
+    $pngs = @()
+    foreach ($s in $sizes) {
+        $out = Join-Path $tmp "icon-$s.png"
+        & magick -density 600 -background none $svg -resize "${s}x${s}" $out
+        if ($LASTEXITCODE -ne 0) { throw "ImageMagick rasterise to ${s}x${s} failed." }
+        $pngs += $out
+    }
+    & magick @pngs $ico
+    if ($LASTEXITCODE -ne 0) { throw "ImageMagick .ico assembly failed." }
+} finally {
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}
+
+Write-Host ("wrote {0} ({1:N0} bytes)" -f $ico, (Get-Item $ico).Length)

--- a/build/make_iconset.sh
+++ b/build/make_iconset.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Render app/assets/icon.svg into app/assets/icon.icns at all macOS sizes.
+# Run locally before building; produces a deterministic .icns that gets bundled.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SVG="$ROOT/app/assets/icon.svg"
+OUT="$ROOT/app/assets/icon.icns"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if [[ ! -f "$SVG" ]]; then
+  echo "icon.svg not found at $SVG" >&2
+  exit 1
+fi
+
+# Render the SVG once at 1024px via Quick Look (built into macOS, no deps).
+qlmanage -t -s 1024 -o "$TMP" "$SVG" >/dev/null
+SRC_PNG="$TMP/$(basename "$SVG").png"
+[[ -f "$SRC_PNG" ]] || { echo "qlmanage rendering failed"; exit 1; }
+
+ICONSET="$TMP/icon.iconset"
+mkdir -p "$ICONSET"
+
+# macOS expects these exact filenames in a .iconset directory.
+declare -a sizes=(
+  "16  icon_16x16.png"
+  "32  icon_16x16@2x.png"
+  "32  icon_32x32.png"
+  "64  icon_32x32@2x.png"
+  "128 icon_128x128.png"
+  "256 icon_128x128@2x.png"
+  "256 icon_256x256.png"
+  "512 icon_256x256@2x.png"
+  "512 icon_512x512.png"
+  "1024 icon_512x512@2x.png"
+)
+for entry in "${sizes[@]}"; do
+  size="${entry%% *}"
+  name="${entry##* }"
+  sips -z "$size" "$size" "$SRC_PNG" --out "$ICONSET/$name" >/dev/null
+done
+
+iconutil -c icns "$ICONSET" -o "$OUT"
+echo "wrote $OUT ($(stat -f '%z' "$OUT") bytes)"

--- a/build/make_zip.ps1
+++ b/build/make_zip.ps1
@@ -1,0 +1,33 @@
+# Package dist/Arc2Zen/ into a single zip a user can drop anywhere.
+# The zip contains the Arc2Zen/ folder at the top level so an extracted
+# folder is self-contained.
+$ErrorActionPreference = 'Stop'
+
+$root = Resolve-Path "$PSScriptRoot/.."
+Push-Location $root
+try {
+    $version = $env:VERSION
+    if (-not $version) { $version = '1.0.0' }
+    $zipName = "Arc2Zen-$version-win-x64.zip"
+    $zipPath = Join-Path 'dist' $zipName
+
+    if (-not (Test-Path 'dist/Arc2Zen')) {
+        throw 'dist/Arc2Zen not found; run build/make_exe.ps1 first.'
+    }
+
+    if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+
+    # Ship the INSTRUCTIONS.txt next to the .exe so users see it as soon
+    # as they extract.
+    if (Test-Path 'build/INSTRUCTIONS.txt') {
+        Copy-Item 'build/INSTRUCTIONS.txt' 'dist/Arc2Zen/INSTRUCTIONS.txt' -Force
+    }
+
+    Write-Host '==> Compress-Archive'
+    Compress-Archive -Path 'dist/Arc2Zen' -DestinationPath $zipPath -CompressionLevel Optimal
+
+    $bytes = (Get-Item $zipPath).Length
+    Write-Host ("==> done: $zipPath ({0:N1} MB)" -f ($bytes / 1MB))
+} finally {
+    Pop-Location
+}

--- a/build/run_app.py
+++ b/build/run_app.py
@@ -1,0 +1,42 @@
+"""PyInstaller entry point. The bundled binary executes this script
+directly, so we cannot rely on `python -m app` semantics. We make sure
+the repo root is on sys.path and then call into the package as if it
+were imported normally."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+
+def _bootstrap_path() -> None:
+    here = Path(__file__).resolve().parent
+    # When running from source (`python build/run_app.py`) the repo root
+    # is the parent of build/. When running inside a PyInstaller bundle
+    # `_MEIPASS` is the unpacked Resources directory.
+    candidates = [here.parent, Path(getattr(sys, "_MEIPASS", ""))]
+    for c in candidates:
+        if c and str(c) not in sys.path:
+            sys.path.insert(0, str(c))
+
+
+def main() -> int:
+    _bootstrap_path()
+    from app.window import launch  # imported after sys.path is fixed
+
+    parser = argparse.ArgumentParser(prog="Arc2Zen")
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable WebKit devtools and verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    launch(debug=args.debug)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrate_arc_to_zen.py
+++ b/migrate_arc_to_zen.py
@@ -27,6 +27,7 @@ from zen_space_importer import ZenSpaceImporter, ZenProfile
 from zen_pinned_tab_importer import ZenPinnedTabImporter
 from zen_workspace_importer import ZenWorkspaceImporter
 from zen_sessions_importer import ZenSessionsImporter
+from zen_favicon_importer import FaviconImporter, _iter_pinned_urls
 
 # Optional: Import sessionstore manager for open tabs (requires lz4)
 try:
@@ -123,6 +124,8 @@ class Arc2ZenMigrator:
         arc_space_name: Optional[str] = None,
         import_open_tabs: bool = False,
         no_containers: bool = False,
+        import_favicons: bool = True,
+        folders_collapsed: bool = True,
     ) -> bool:
         """Run the complete Arc to Zen migration process."""
 
@@ -294,7 +297,7 @@ class Arc2ZenMigrator:
         if uses_sessions:
             # Zen 1.18+: Import spaces, pinned tabs, and folders into zen-sessions.jsonlz4
             print("\n📌 Step 4b: Importing pinned tabs and workspaces (modern format)...")
-            sessions_importer = ZenSessionsImporter(selected_zen_profile)
+            sessions_importer = ZenSessionsImporter(selected_zen_profile, folders_collapsed=folders_collapsed)
             sessions_success = sessions_importer.import_arc_data(arc_export_data, container_mappings, dry_run=dry_run)
             pinned_success = sessions_success
             workspace_success = sessions_success
@@ -313,7 +316,35 @@ class Arc2ZenMigrator:
         print("\n📚 Step 4d: Importing as bookmarks...")
         bookmark_success = zen_importer.import_arc_bookmarks(arc_export_data, dry_run=dry_run)
 
-        # Step 4e: Import open tabs to sessionstore
+        # Step 4e: Copy favicons from Arc to Zen so they show up immediately
+        favicon_success = True
+        favicon_summary = None
+        if import_favicons:
+            print("\n🖼️  Step 4e: Importing favicons from Arc...")
+            try:
+                favicon_importer = FaviconImporter(selected_zen_profile, dry_run=dry_run)
+                urls = list(dict.fromkeys(_iter_pinned_urls(arc_export_data)))
+                db_summary = favicon_importer.import_favicons(urls)
+                session_summary = favicon_importer.inject_session_images(urls)
+                favicon_summary = {'db': db_summary, 'session': session_summary}
+                matched = db_summary.get('matched', 0)
+                requested = db_summary.get('requested', 0)
+                if dry_run:
+                    print(f"🧪 Would import {matched}/{requested} favicons")
+                else:
+                    imported = db_summary.get('imported', 0)
+                    updated = session_summary.get('updated', 0)
+                    print(f"✅ Imported {imported} favicons → favicons.sqlite, "
+                          f"inlined {updated} tabs in zen-sessions.jsonlz4 "
+                          f"(matched {matched}/{requested} URLs)")
+            except Exception as e:
+                print(f"⚠️  Favicon import error: {e}")
+                logger.exception("Favicon import failed")
+                favicon_success = False
+        else:
+            print("\n🖼️  Step 4e: Favicon import skipped (--skip-favicons)")
+
+        # Step 4f: Import open tabs to sessionstore
         print("\n🔄 Step 4f: Importing open tabs...")
         session_success = True
         total_open_tabs = sum(len(space.get('open_tabs', [])) for space in arc_export_data.get('spaces', []))
@@ -341,7 +372,14 @@ class Arc2ZenMigrator:
         else:
             print("ℹ️  No open tabs to import")
 
-        success = space_success and pinned_success and workspace_success and bookmark_success and session_success
+        success = (
+            space_success
+            and pinned_success
+            and workspace_success
+            and bookmark_success
+            and session_success
+            and favicon_success
+        )
 
         # Cleanup
         if self.temp_export_file.exists():
@@ -437,6 +475,18 @@ Examples:
         help='Do not assign any container to tabs (container ID 0 - regular browsing). By default, separate containers are created for each Arc space. You can manually assign containers later in Zen.'
     )
 
+    parser.add_argument(
+        '--skip-favicons',
+        action='store_true',
+        help='Skip importing favicons from Arc. By default, favicons are copied so tabs show their icons immediately.'
+    )
+
+    parser.add_argument(
+        '--folders-open',
+        action='store_true',
+        help='Import folders in expanded state. By default they are collapsed to reduce sidebar clutter after migration.'
+    )
+
     args = parser.parse_args()
 
     if args.verbose:
@@ -452,6 +502,8 @@ Examples:
             arc_space_name=args.arc_space,
             import_open_tabs=args.open_tabs,
             no_containers=args.no_containers,
+            import_favicons=not args.skip_favicons,
+            folders_collapsed=not args.folders_open,
         )
 
         if success and not args.dry_run:

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,13 @@
 # Build-time deps for the GUI bundle. Not needed at runtime once installed.
 pywebview>=6.0
 pyinstaller>=6.0
-pyobjc-framework-WebKit
-pyobjc-framework-Cocoa
+
+# macOS: PyWebView's Cocoa backend needs pyobjc.
+pyobjc-framework-WebKit ; sys_platform == "darwin"
+pyobjc-framework-Cocoa  ; sys_platform == "darwin"
+
+# Windows: PyWebView's WebView2 (Edge Chromium) backend needs pythonnet
+# for the COM interop layer. Without this, PyInstaller-bundled .exe
+# crashes on first window create with `ModuleNotFoundError: No module
+# named 'clr'`.
+pythonnet>=3.0 ; sys_platform == "win32"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,5 @@
+# Build-time deps for the GUI bundle. Not needed at runtime once installed.
+pywebview>=6.0
+pyinstaller>=6.0
+pyobjc-framework-WebKit
+pyobjc-framework-Cocoa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lz4>=4.0.0
+cryptography>=42.0.0

--- a/src/arc_cookies_importer.py
+++ b/src/arc_cookies_importer.py
@@ -2,18 +2,31 @@
 """
 Arc → Zen Cookies Importer
 
-Decrypts Arc's Chromium-format cookies (AES-128-CBC, key derived from the
-macOS Keychain "Arc Safe Storage" entry) and writes them into Zen's
+Decrypts Arc's Chromium-format cookies and writes them into Zen's
 Firefox-format `cookies.sqlite` so login sessions carry over.
 
-macOS only. Reading the Keychain may trigger an "always allow / allow"
-prompt the first time. The script is idempotent: re-running merges new
-cookies without duplicating existing ones.
+Supports macOS and Windows:
+
+- **macOS**: master key fetched from the Keychain entry "Arc Safe Storage",
+  derived via PBKDF2 (1003 iterations, salt "saltysalt") to a 16-byte
+  AES-128 key. Cookie blobs prefixed `v10` use AES-128-CBC with an
+  all-spaces IV and PKCS7 padding.
+- **Windows**: master key read from `Local State` JSON, base64-decoded,
+  unwrapped via Windows DPAPI (`crypt32!CryptUnprotectData` through
+  ctypes). Cookie blobs prefixed `v10` use AES-256-GCM (12-byte nonce
+  + ciphertext + 16-byte authentication tag).
+
+The Firefox-side write (`moz_cookies` insert, container duplication,
+ms-vs-seconds expiry handling) is identical across platforms. Re-running
+merges new cookies without duplicating existing ones.
 """
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
+import os
 import shutil
 import sqlite3
 import subprocess
@@ -21,7 +34,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Callable, Iterable, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +75,7 @@ def _read_keychain_password(service: str = "Arc Safe Storage", account: str = "A
     return None
 
 
-def _derive_aes_key(password: str) -> bytes:
+def _derive_aes_key_macos(password: str) -> bytes:
     """Chromium on macOS: PBKDF2-HMAC-SHA1, salt='saltysalt', iterations=1003, keylen=16."""
     from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
     from cryptography.hazmat.primitives import hashes
@@ -76,8 +89,8 @@ def _derive_aes_key(password: str) -> bytes:
     return kdf.derive(password.encode("utf-8"))
 
 
-def _decrypt_v10(blob: bytes, key: bytes) -> Optional[bytes]:
-    """Strip 'v10' magic, AES-128-CBC decrypt with all-spaces IV, strip PKCS7 padding."""
+def _decrypt_v10_cbc(blob: bytes, key: bytes) -> Optional[bytes]:
+    """macOS path. Strip 'v10' magic, AES-128-CBC decrypt with all-spaces IV, PKCS7 unpad."""
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
     if not blob.startswith(b"v10"):
@@ -92,8 +105,138 @@ def _decrypt_v10(blob: bytes, key: bytes) -> Optional[bytes]:
     pad = padded[-1] if padded else 0
     if 0 < pad <= 16 and padded.endswith(bytes([pad]) * pad):
         padded = padded[:-pad]
-    # Newer Chromium versions prepend a 32-byte SHA-256 of the host as integrity tag.
     return padded
+
+
+# ---------- Windows DPAPI master-key unwrap ----------
+
+class _DpapiError(RuntimeError):
+    """Raised when Windows DPAPI rejects the encrypted blob.
+
+    The ``code`` attribute carries an orchestrator-friendly error key.
+    """
+
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(message or code)
+        self.code = code
+
+
+def _arc_local_state_paths() -> list[Path]:
+    """Return Local State JSON candidates across both Windows install vectors."""
+    home = Path.home()
+    if os.name != "nt":
+        return []
+    candidates = [
+        home / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+             / "LocalCache/Local/Arc/User Data/Local State",
+        home / "AppData/Local/Arc/User Data/Local State",
+    ]
+    return [p for p in candidates if p.is_file()]
+
+
+def _crypt_unprotect_data(blob: bytes) -> bytes:
+    """Call ``crypt32!CryptUnprotectData`` via ctypes and return the plaintext.
+
+    Raises ``_DpapiError`` with a structured code on failure.
+    """
+    import ctypes
+    from ctypes import wintypes  # type: ignore[import-not-found]
+
+    class DATA_BLOB(ctypes.Structure):
+        _fields_ = [("cbData", wintypes.DWORD), ("pbData", ctypes.POINTER(ctypes.c_char))]
+
+    crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    crypt32.CryptUnprotectData.argtypes = [
+        ctypes.POINTER(DATA_BLOB), ctypes.c_void_p, ctypes.POINTER(DATA_BLOB),
+        ctypes.c_void_p, ctypes.c_void_p, wintypes.DWORD, ctypes.POINTER(DATA_BLOB),
+    ]
+    crypt32.CryptUnprotectData.restype = wintypes.BOOL
+
+    buf = ctypes.create_string_buffer(blob, len(blob))
+    in_blob = DATA_BLOB(len(blob), ctypes.cast(buf, ctypes.POINTER(ctypes.c_char)))
+    out_blob = DATA_BLOB()
+    CRYPTPROTECT_UI_FORBIDDEN = 0x1
+
+    ok = crypt32.CryptUnprotectData(
+        ctypes.byref(in_blob), None, None, None, None,
+        CRYPTPROTECT_UI_FORBIDDEN, ctypes.byref(out_blob),
+    )
+    if not ok:
+        err = ctypes.get_last_error()
+        # ERROR_INVALID_DATA (13) is the canonical "different user" symptom.
+        code = "dpapi_wrong_user" if err == 13 else "dpapi_failed"
+        raise _DpapiError(code, f"CryptUnprotectData failed (GetLastError={err})")
+
+    try:
+        size = int(out_blob.cbData)
+        plaintext = ctypes.string_at(out_blob.pbData, size)
+        return plaintext
+    finally:
+        # Free the allocation Windows made for us.
+        kernel32.LocalFree(out_blob.pbData)
+
+
+def _read_local_state_key_windows() -> bytes:
+    """Read Arc's ``Local State`` and unwrap the master key.
+
+    Raises ``_DpapiError`` with a structured code on any failure path.
+    """
+    paths = _arc_local_state_paths()
+    if not paths:
+        raise _DpapiError(
+            "arc_local_state_missing",
+            "Arc has not been launched on this Windows account yet.",
+        )
+    state = json.loads(paths[0].read_text(encoding="utf-8"))
+    encrypted_b64 = state.get("os_crypt", {}).get("encrypted_key")
+    if not encrypted_b64:
+        raise _DpapiError(
+            "arc_no_encrypted_key",
+            "Arc Local State has no os_crypt.encrypted_key entry.",
+        )
+
+    raw = base64.b64decode(encrypted_b64)
+    if raw.startswith(b"APPB"):
+        # Chromium v20 / Brave / Edge app-bound encryption; not defeatable
+        # without invoking Chromium's elevated COM service.
+        raise _DpapiError(
+            "arc_appbound_encryption",
+            "Arc cookies use app-bound (v20) encryption.",
+        )
+    if not raw.startswith(b"DPAPI"):
+        raise _DpapiError(
+            "arc_unknown_key_prefix",
+            f"Unexpected key prefix {raw[:5]!r}",
+        )
+
+    key = _crypt_unprotect_data(raw[5:])
+    if len(key) != 32:
+        raise _DpapiError(
+            "arc_unexpected_key_length",
+            f"Got {len(key)}-byte key from DPAPI; expected 32 bytes.",
+        )
+    return key
+
+
+def _decrypt_v10_gcm(blob: bytes, key: bytes) -> Optional[bytes]:
+    """Windows path. Strip 'v10' magic, AES-256-GCM decrypt with the embedded nonce.
+
+    Layout: ``b"v10" + nonce[12] + ciphertext + tag[16]``.
+    Returns the plaintext or ``None`` on prefix/format mismatch. The
+    caller swallows individual decrypt failures and counts them.
+    """
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    from cryptography.exceptions import InvalidTag
+
+    if not blob.startswith(b"v10") or len(blob) < 3 + 12 + 16:
+        return None
+    nonce = blob[3:15]
+    ct_and_tag = blob[15:]
+    try:
+        return AESGCM(key).decrypt(nonce, ct_and_tag, None)
+    except InvalidTag:
+        return None
 
 
 def _strip_host_hash(plaintext: bytes) -> bytes:
@@ -118,9 +261,34 @@ _SAMESITE_MAP = {-1: 3, 0: 0, 1: 1, 2: 2}
 
 
 def _arc_cookie_dbs() -> list[Path]:
+    """Locate every Arc profile's Cookies SQLite across both supported OSes.
+
+    Newer Chromium builds nest the file as ``<profile>/Network/Cookies``;
+    older builds keep it at ``<profile>/Cookies``. We accept either.
+    """
     home = Path.home()
-    macos = home / "Library/Application Support/Arc/User Data"
-    return sorted(p for p in macos.glob("*/Cookies") if p.is_file()) if macos.exists() else []
+    roots: list[Path] = []
+    if sys.platform == "darwin":
+        roots.append(home / "Library/Application Support/Arc/User Data")
+    elif os.name == "nt":
+        roots.append(
+            home / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+                 / "LocalCache/Local/Arc/User Data"
+        )
+        roots.append(home / "AppData/Local/Arc/User Data")
+
+    found: list[Path] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for profile in sorted(root.iterdir()):
+            if not profile.is_dir():
+                continue
+            for candidate in (profile / "Network" / "Cookies", profile / "Cookies"):
+                if candidate.is_file():
+                    found.append(candidate)
+                    break
+    return found
 
 
 class CookiesImporter:
@@ -157,7 +325,12 @@ class CookiesImporter:
             shutil.rmtree(self._tempdir, ignore_errors=True)
             self._tempdir = None
 
-    def _decrypt_rows(self, rows: Iterable[sqlite3.Row], key: bytes) -> Iterable[dict]:
+    def _decrypt_rows(
+        self,
+        rows: Iterable[sqlite3.Row],
+        key: bytes,
+        decrypt_fn: Callable[[bytes, bytes], Optional[bytes]],
+    ) -> Iterable[dict]:
         decrypt_fail = 0
         decoded = 0
 
@@ -176,7 +349,7 @@ class CookiesImporter:
             value = s(raw_value)
             blob = row["encrypted_value"]
             if not value and blob:
-                pt = _decrypt_v10(bytes(blob), key)
+                pt = decrypt_fn(bytes(blob), key)
                 if pt is None:
                     decrypt_fail += 1
                     continue
@@ -213,24 +386,39 @@ class CookiesImporter:
         if decoded:
             logger.info(f"🔓 Decrypted {decoded} encrypted cookie values")
 
+    def _resolve_key_and_decrypt_fn(self) -> Tuple[bytes, Callable[[bytes, bytes], Optional[bytes]], Optional[str]]:
+        """Return ``(key, decrypt_fn, None)`` on success or ``(b"", noop, error_code)``.
+
+        Hides macOS Keychain vs Windows DPAPI behind a single dispatch.
+        """
+        if sys.platform == "darwin":
+            password = _read_keychain_password()
+            if password is None:
+                return b"", _decrypt_v10_cbc, "keychain_denied"
+            return _derive_aes_key_macos(password), _decrypt_v10_cbc, None
+
+        if os.name == "nt":
+            try:
+                key = _read_local_state_key_windows()
+            except _DpapiError as exc:
+                logger.error(f"DPAPI key unwrap failed: {exc} ({exc.code})")
+                return b"", _decrypt_v10_gcm, exc.code
+            return key, _decrypt_v10_gcm, None
+
+        return b"", _decrypt_v10_cbc, "unsupported_platform"
+
     def import_cookies(self) -> dict:
         result = {"read": 0, "imported": 0, "merged": 0, "skipped": 0}
-
-        if sys.platform != "darwin":
-            logger.error("Cookie import currently supports macOS only")
-            result["error"] = "unsupported_platform"
-            return result
 
         if not self.zen_cookies.exists():
             logger.error(f"Zen cookies.sqlite not found at {self.zen_cookies}")
             result["error"] = "cookies_db_missing"
             return result
 
-        password = _read_keychain_password()
-        if password is None:
-            result["error"] = "keychain_denied"
+        key, decrypt_fn, err = self._resolve_key_and_decrypt_fn()
+        if err:
+            result["error"] = err
             return result
-        key = _derive_aes_key(password)
 
         cookies: list[dict] = []
         try:
@@ -254,7 +442,7 @@ class CookiesImporter:
                     )
                     rows = cur.fetchall()
                     result["read"] += len(rows)
-                    cookies.extend(self._decrypt_rows(rows, key))
+                    cookies.extend(self._decrypt_rows(rows, key, decrypt_fn))
                 finally:
                     conn.close()
         finally:

--- a/src/arc_cookies_importer.py
+++ b/src/arc_cookies_importer.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Arc → Zen Cookies Importer
+
+Decrypts Arc's Chromium-format cookies (AES-128-CBC, key derived from the
+macOS Keychain "Arc Safe Storage" entry) and writes them into Zen's
+Firefox-format `cookies.sqlite` so login sessions carry over.
+
+macOS only. Reading the Keychain may trigger an "always allow / allow"
+prompt the first time. The script is idempotent — re-running merges new
+cookies without duplicating existing ones.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+_WEBKIT_EPOCH_OFFSET_US = 11_644_473_600_000_000
+
+
+def _chrome_to_unix_us(chrome_us: Optional[int]) -> int:
+    if not chrome_us:
+        return 0
+    val = chrome_us - _WEBKIT_EPOCH_OFFSET_US
+    return val if val > 0 else 0
+
+
+def _read_keychain_password(service: str = "Arc Safe Storage", account: str = "Arc") -> Optional[str]:
+    """Fetch the per-app Chromium safe-storage key from macOS Keychain.
+
+    Arc registers the entry with svce="Arc Safe Storage" and acct="Arc".
+    Searching by service alone falls back to account-blind lookup, but
+    that's what triggers the "could not be found" error on some setups.
+    """
+    attempts = [
+        ["security", "find-generic-password", "-s", service, "-a", account, "-w"],
+        ["security", "find-generic-password", "-s", service, "-w"],
+        ["security", "find-generic-password", "-wa", service],
+    ]
+    last_err = ""
+    for cmd in attempts:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            logger.error("Keychain lookup timed out (likely awaiting user approval).")
+            return None
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        last_err = result.stderr.strip()
+    logger.error(f"Keychain returned error for {service!r}: {last_err or 'denied'}")
+    return None
+
+
+def _derive_aes_key(password: str) -> bytes:
+    """Chromium on macOS: PBKDF2-HMAC-SHA1, salt='saltysalt', iterations=1003, keylen=16."""
+    from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    from cryptography.hazmat.primitives import hashes
+
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA1(),
+        length=16,
+        salt=b"saltysalt",
+        iterations=1003,
+    )
+    return kdf.derive(password.encode("utf-8"))
+
+
+def _decrypt_v10(blob: bytes, key: bytes) -> Optional[bytes]:
+    """Strip 'v10' magic, AES-128-CBC decrypt with all-spaces IV, strip PKCS7 padding."""
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    if not blob.startswith(b"v10"):
+        return None
+    ciphertext = blob[3:]
+    if len(ciphertext) % 16 != 0:
+        return None
+    iv = b" " * 16
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(ciphertext) + decryptor.finalize()
+    pad = padded[-1] if padded else 0
+    if 0 < pad <= 16 and padded.endswith(bytes([pad]) * pad):
+        padded = padded[:-pad]
+    # Newer Chromium versions prepend a 32-byte SHA-256 of the host as integrity tag.
+    return padded
+
+
+def _strip_host_hash(plaintext: bytes) -> bytes:
+    """Some Chromium builds prefix the plaintext with a 32-byte SHA-256(host) tag.
+
+    We don't know up-front which builds use it. Heuristic: if the first 32 bytes
+    are non-printable and the remainder is printable, drop the tag.
+    """
+    if len(plaintext) < 33:
+        return plaintext
+    head, tail = plaintext[:32], plaintext[32:]
+    if any(b < 0x20 or b > 0x7E for b in head) and all(0x09 <= b <= 0x7E or b == 0x0A for b in tail):
+        return tail
+    return plaintext
+
+
+# Chromium SameSite (samesite enum in net/cookies/cookie_constants.h):
+#   -1 UNSPECIFIED, 0 NO_RESTRICTION, 1 LAX, 2 STRICT
+# Firefox sameSite (in nsICookie.idl):
+#   0 SAMESITE_NONE, 1 SAMESITE_LAX, 2 SAMESITE_STRICT, 3 SAMESITE_UNSET
+_SAMESITE_MAP = {-1: 3, 0: 0, 1: 1, 2: 2}
+
+
+def _arc_cookie_dbs() -> list[Path]:
+    home = Path.home()
+    macos = home / "Library/Application Support/Arc/User Data"
+    return sorted(p for p in macos.glob("*/Cookies") if p.is_file()) if macos.exists() else []
+
+
+class CookiesImporter:
+    # Session cookies (Chromium has_expires=0) get this many days of fake
+    # persistence in Firefox so Firefox's startup sweep doesn't immediately
+    # purge them as expired.
+    SESSION_COOKIE_DAYS = 30
+
+    def __init__(
+        self,
+        zen_profile: Path,
+        dry_run: bool = False,
+        container_ids: Optional[list[int]] = None,
+    ):
+        self.zen_profile = Path(zen_profile)
+        self.zen_cookies = self.zen_profile / "cookies.sqlite"
+        self.dry_run = dry_run
+        self.container_ids = container_ids or []
+        self._tempdir: Optional[Path] = None
+
+    def _snapshot(self, src: Path) -> Path:
+        if self._tempdir is None:
+            self._tempdir = Path(tempfile.mkdtemp(prefix="arc2zen_cookies_"))
+        dest = self._tempdir / f"{src.parent.name}_{src.name}.db"
+        shutil.copy2(src, dest)
+        for suffix in ("-wal", "-shm", "-journal"):
+            sib = src.with_name(src.name + suffix)
+            if sib.exists():
+                shutil.copy2(sib, dest.with_name(dest.name + suffix))
+        return dest
+
+    def _cleanup(self) -> None:
+        if self._tempdir and self._tempdir.exists():
+            shutil.rmtree(self._tempdir, ignore_errors=True)
+            self._tempdir = None
+
+    def _decrypt_rows(self, rows: Iterable[sqlite3.Row], key: bytes) -> Iterable[dict]:
+        decrypt_fail = 0
+        decoded = 0
+
+        def s(b) -> str:
+            if b is None:
+                return ""
+            if isinstance(b, str):
+                return b
+            try:
+                return b.decode("utf-8")
+            except UnicodeDecodeError:
+                return b.decode("latin-1", errors="replace")
+
+        for row in rows:
+            raw_value = row["value"]
+            value = s(raw_value)
+            blob = row["encrypted_value"]
+            if not value and blob:
+                pt = _decrypt_v10(bytes(blob), key)
+                if pt is None:
+                    decrypt_fail += 1
+                    continue
+                pt = _strip_host_hash(pt)
+                try:
+                    value = pt.decode("utf-8")
+                except UnicodeDecodeError:
+                    decrypt_fail += 1
+                    continue
+                decoded += 1
+            elif not value and not blob:
+                continue
+            # Map Chromium source_scheme (0=unset, 1=http, 2=https) to
+            # Firefox schemeMap (0=unset, 1=http, 2=https, 4=file).
+            src_scheme = row["source_scheme"] if "source_scheme" in row.keys() else 0
+            scheme_map = src_scheme if src_scheme in (1, 2) else (2 if row["is_secure"] else 1)
+
+            yield {
+                "host_key": s(row["host_key"]),
+                "name": s(row["name"]),
+                "value": value,
+                "path": s(row["path"]),
+                "expires_us": _chrome_to_unix_us(row["expires_utc"]),
+                "creation_us": _chrome_to_unix_us(row["creation_utc"]),
+                "last_access_us": _chrome_to_unix_us(row["last_access_utc"]),
+                "is_secure": row["is_secure"],
+                "is_httponly": row["is_httponly"],
+                "samesite": _SAMESITE_MAP.get(row["samesite"], 3),
+                "has_expires": row["has_expires"] if "has_expires" in row.keys() else 1,
+                "scheme_map": scheme_map,
+            }
+        if decrypt_fail:
+            logger.warning(f"⚠️  Skipped {decrypt_fail} cookies that could not be decrypted")
+        if decoded:
+            logger.info(f"🔓 Decrypted {decoded} encrypted cookie values")
+
+    def import_cookies(self) -> dict:
+        result = {"read": 0, "imported": 0, "merged": 0, "skipped": 0}
+
+        if sys.platform != "darwin":
+            logger.error("Cookie import currently supports macOS only")
+            result["error"] = "unsupported_platform"
+            return result
+
+        if not self.zen_cookies.exists():
+            logger.error(f"Zen cookies.sqlite not found at {self.zen_cookies}")
+            result["error"] = "cookies_db_missing"
+            return result
+
+        password = _read_keychain_password()
+        if password is None:
+            result["error"] = "keychain_denied"
+            return result
+        key = _derive_aes_key(password)
+
+        cookies: list[dict] = []
+        try:
+            for arc_db in _arc_cookie_dbs():
+                logger.info(f"📖 Reading Arc cookies from {arc_db.parent.name}")
+                snap = self._snapshot(arc_db)
+                conn = sqlite3.connect(f"file:{snap}?mode=ro", uri=True)
+                # encrypted_value is binary; some Chromium builds also stash
+                # bytes in TEXT columns. Tell sqlite3 not to UTF-8-decode anything,
+                # and we'll decode the str fields ourselves.
+                conn.text_factory = bytes
+                conn.row_factory = sqlite3.Row
+                try:
+                    cur = conn.cursor()
+                    cur.execute(
+                        """SELECT host_key, name, value, encrypted_value, path,
+                                  expires_utc, creation_utc, last_access_utc,
+                                  is_secure, is_httponly, samesite,
+                                  has_expires, source_scheme
+                           FROM cookies"""
+                    )
+                    rows = cur.fetchall()
+                    result["read"] += len(rows)
+                    cookies.extend(self._decrypt_rows(rows, key))
+                finally:
+                    conn.close()
+        finally:
+            self._cleanup()
+
+        logger.info(f"🔍 Decoded {len(cookies)} of {result['read']} cookies from Arc")
+        if not cookies:
+            return result
+
+        if self.dry_run:
+            result["dry_run"] = True
+            result["imported"] = len(cookies)
+            return result
+
+        backup = self.zen_cookies.with_name(f"{self.zen_cookies.name}.backup.{int(time.time())}")
+        shutil.copy2(self.zen_cookies, backup)
+        logger.info(f"💾 Backed up cookies.sqlite → {backup.name}")
+
+        conn = sqlite3.connect(self.zen_cookies, timeout=30.0)
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN")
+            now_us = int(time.time() * 1_000_000)
+            now_ms = now_us // 1000
+            session_expiry_ms = now_ms + self.SESSION_COOKIE_DAYS * 86400 * 1000
+
+            # Targets: default context (empty) plus every container we were told about.
+            origin_targets = [""] + [f"^userContextId={cid}" for cid in self.container_ids]
+
+            for c in cookies:
+                # Modern Firefox stores `expiry` as MILLISECONDS since epoch
+                # (legacy was seconds — switched ~v108). Surviving native cookies
+                # in this profile confirmed the new format.
+                if not c["has_expires"] or not c["expires_us"]:
+                    expiry_ms = session_expiry_ms
+                else:
+                    expiry_ms = c["expires_us"] // 1000
+
+                host = c["host_key"]
+                last_accessed_us = c["last_access_us"] or now_us
+                creation_us = c["creation_us"] or now_us
+                for oa in origin_targets:
+                    try:
+                        cur.execute(
+                            """INSERT INTO moz_cookies
+                               (originAttributes, name, value, host, path, expiry,
+                                lastAccessed, creationTime, isSecure, isHttpOnly,
+                                sameSite, schemeMap, updateTime)
+                               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                            (
+                                oa,
+                                c["name"],
+                                c["value"],
+                                host,
+                                c["path"],
+                                expiry_ms,
+                                last_accessed_us,
+                                creation_us,
+                                int(bool(c["is_secure"])),
+                                int(bool(c["is_httponly"])),
+                                c["samesite"],
+                                c["scheme_map"],
+                                last_accessed_us,
+                            ),
+                        )
+                        result["imported"] += 1
+                    except sqlite3.IntegrityError:
+                        cur.execute(
+                            """UPDATE moz_cookies
+                                  SET value = ?, expiry = ?, lastAccessed = ?,
+                                      isSecure = ?, isHttpOnly = ?, sameSite = ?,
+                                      schemeMap = ?, updateTime = ?
+                               WHERE originAttributes = ? AND name = ?
+                                 AND host = ? AND path = ?""",
+                            (
+                                c["value"],
+                                expiry_ms,
+                                last_accessed_us,
+                                int(bool(c["is_secure"])),
+                                int(bool(c["is_httponly"])),
+                                c["samesite"],
+                                c["scheme_map"],
+                                last_accessed_us,
+                                oa,
+                                c["name"],
+                                host,
+                                c["path"],
+                            ),
+                        )
+                        result["merged"] += 1
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        logger.info(
+            f"✅ Cookies: imported {result['imported']}, merged {result['merged']} "
+            f"across {len(origin_targets)} origin contexts"
+        )
+        return result
+
+
+def _discover_user_containers(zen_profile: Path) -> list[int]:
+    """Read containers.json and return userContextIds for non-internal identities."""
+    import json
+    cf = zen_profile / "containers.json"
+    if not cf.exists():
+        return []
+    try:
+        data = json.loads(cf.read_text())
+    except Exception:
+        return []
+    out: list[int] = []
+    for identity in data.get("identities", []):
+        cid = identity.get("userContextId", 0)
+        # Skip internal (l10nID starting with userContextIdInternal) and the
+        # default (0) and the 4294967295 sentinel.
+        l10n = identity.get("l10nID", "") or ""
+        if cid and cid < 1_000_000 and not l10n.startswith("userContextIdInternal"):
+            out.append(cid)
+    return sorted(set(out))
+
+
+def main() -> int:
+    import argparse
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    parser = argparse.ArgumentParser(description="Import Arc cookies into Zen")
+    parser.add_argument("--zen-profile", help="Zen profile name (partial match)")
+    parser.add_argument(
+        "--containers",
+        help="Comma-separated userContextIds to also populate (so cookies work "
+             "in container tabs). Pass 'auto' to read containers.json and use "
+             "every non-internal identity. Default: auto.",
+        default="auto",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    profiles_root = Path.home() / "Library/Application Support/zen/Profiles"
+    profiles = [p for p in profiles_root.iterdir() if p.is_dir()] if profiles_root.exists() else []
+    if args.zen_profile:
+        profiles = [p for p in profiles if args.zen_profile.lower() in p.name.lower()]
+    if not profiles:
+        logger.error("No matching Zen profile found")
+        return 1
+    zen_profile = profiles[0]
+    logger.info(f"Using Zen profile: {zen_profile.name}")
+
+    container_ids: list[int] = []
+    if args.containers == "auto":
+        container_ids = _discover_user_containers(zen_profile)
+    elif args.containers:
+        container_ids = [int(x) for x in args.containers.split(",") if x.strip().isdigit()]
+    if container_ids:
+        logger.info(f"Will populate containers: {container_ids}")
+
+    importer = CookiesImporter(zen_profile, dry_run=args.dry_run, container_ids=container_ids)
+    summary = importer.import_cookies()
+    logger.info(f"Summary: {summary}")
+    return 0 if not summary.get("error") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/arc_cookies_importer.py
+++ b/src/arc_cookies_importer.py
@@ -7,7 +7,7 @@ macOS Keychain "Arc Safe Storage" entry) and writes them into Zen's
 Firefox-format `cookies.sqlite` so login sessions carry over.
 
 macOS only. Reading the Keychain may trigger an "always allow / allow"
-prompt the first time. The script is idempotent — re-running merges new
+prompt the first time. The script is idempotent: re-running merges new
 cookies without duplicating existing ones.
 """
 
@@ -286,7 +286,7 @@ class CookiesImporter:
 
             for c in cookies:
                 # Modern Firefox stores `expiry` as MILLISECONDS since epoch
-                # (legacy was seconds — switched ~v108). Surviving native cookies
+                # (legacy was seconds; switched ~v108). Surviving native cookies
                 # in this profile confirmed the new format.
                 if not c["has_expires"] or not c["expires_us"]:
                     expiry_ms = session_expiry_ms

--- a/src/arc_history_importer.py
+++ b/src/arc_history_importer.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Arc → Zen History Importer
+
+Copies Arc's browsing history (Chromium `History` SQLite) into Zen's
+Firefox-format `places.sqlite`. Handles WebKit→Unix time conversion and
+Chromium→Firefox transition mapping. Idempotent: re-running merges new
+visits without duplicating existing places/visits.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# Reuse Firefox URL hash from the favicon importer so moz_places.url_hash matches.
+from zen_favicon_importer import hash_page_url
+
+
+# Chrome PageTransition enum (chrome/common/page_transition_types.h) → Firefox visit_type.
+# Firefox values: 1=link, 2=typed, 3=bookmark, 4=embed, 5=redirect_perm,
+#                 6=redirect_temp, 7=download, 8=framed_link, 9=reload.
+_CHROMIUM_CORE_TRANSITION = {
+    0: 1,   # LINK -> link
+    1: 2,   # TYPED -> typed
+    2: 3,   # AUTO_BOOKMARK -> bookmark
+    3: 8,   # AUTO_SUBFRAME -> framed_link
+    4: 4,   # MANUAL_SUBFRAME -> embed
+    5: 1,   # GENERATED -> link
+    6: 1,   # AUTO_TOPLEVEL -> link
+    7: 1,   # FORM_SUBMIT -> link
+    8: 9,   # RELOAD -> reload
+    9: 1,   # KEYWORD -> link
+    10: 1,  # KEYWORD_GENERATED -> link
+}
+_CHROMIUM_REDIRECT_PERMANENT = 0x08000000
+_CHROMIUM_REDIRECT_TEMPORARY = 0x04000000
+
+# Webkit/Chrome epoch is 1601-01-01; Unix epoch is 1970-01-01.
+_WEBKIT_EPOCH_OFFSET_US = 11_644_473_600_000_000
+
+
+def _chrome_to_unix_us(chrome_us: Optional[int]) -> int:
+    if not chrome_us:
+        return 0
+    val = chrome_us - _WEBKIT_EPOCH_OFFSET_US
+    return val if val > 0 else 0
+
+
+def _map_transition(chrome_transition: int) -> int:
+    if chrome_transition & _CHROMIUM_REDIRECT_PERMANENT:
+        return 5
+    if chrome_transition & _CHROMIUM_REDIRECT_TEMPORARY:
+        return 6
+    core = chrome_transition & 0xFF
+    return _CHROMIUM_CORE_TRANSITION.get(core, 1)
+
+
+def _reverse_host(url: str) -> str:
+    """Firefox stores hosts reversed with trailing dot (`moc.elgoog.www.`)."""
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return ""
+    return host[::-1] + "." if host else ""
+
+
+class HistoryImporter:
+    def __init__(self, zen_profile: Path, dry_run: bool = False):
+        self.zen_profile = Path(zen_profile)
+        self.places_db = self.zen_profile / "places.sqlite"
+        self.dry_run = dry_run
+        self._tempdir: Optional[Path] = None
+
+    def _arc_history_dbs(self) -> list[Path]:
+        roots: list[Path] = []
+        home = Path.home()
+        macos = home / "Library/Application Support/Arc/User Data"
+        windows = (
+            home
+            / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+            / "LocalCache/Local/Arc/User Data"
+        )
+        for root in (macos, windows):
+            if root.exists():
+                roots.extend(p for p in root.glob("*/History") if p.is_file())
+        return sorted(set(roots))
+
+    def _snapshot(self, src: Path) -> Path:
+        if self._tempdir is None:
+            self._tempdir = Path(tempfile.mkdtemp(prefix="arc2zen_history_"))
+        dest = self._tempdir / f"{src.parent.name}_{src.name}.db"
+        shutil.copy2(src, dest)
+        for suffix in ("-wal", "-shm", "-journal"):
+            sib = src.with_name(src.name + suffix)
+            if sib.exists():
+                shutil.copy2(sib, dest.with_name(dest.name + suffix))
+        return dest
+
+    def _cleanup(self) -> None:
+        if self._tempdir and self._tempdir.exists():
+            shutil.rmtree(self._tempdir, ignore_errors=True)
+            self._tempdir = None
+
+    def import_history(self, since_days: Optional[int] = None) -> dict:
+        """Import Arc history into places.sqlite.
+
+        since_days: only import visits newer than this many days. None = all.
+        """
+        result = {"places_added": 0, "places_updated": 0, "visits_added": 0, "skipped": 0}
+        if not self.places_db.exists():
+            logger.error(f"Zen places.sqlite not found at {self.places_db}")
+            result["error"] = "places_missing"
+            return result
+
+        cutoff_unix_us = 0
+        if since_days:
+            cutoff_unix_us = int((time.time() - since_days * 86400) * 1_000_000)
+
+        # Aggregate Arc data across profiles in memory.
+        # Map url -> (title, total_visits, last_visit_unix_us, [(visit_unix_us, transition)])
+        urls_to_data: dict[str, dict] = {}
+        try:
+            for arc_db in self._arc_history_dbs():
+                logger.info(f"📖 Reading Arc history from {arc_db.parent.name}")
+                snap = self._snapshot(arc_db)
+                conn = sqlite3.connect(f"file:{snap}?mode=ro", uri=True)
+                conn.row_factory = sqlite3.Row
+                try:
+                    cur = conn.cursor()
+                    cur.execute(
+                        """
+                        SELECT u.url AS url,
+                               u.title AS title,
+                               v.visit_time AS visit_time,
+                               v.transition AS transition
+                        FROM visits v JOIN urls u ON u.id = v.url
+                        WHERE u.url LIKE 'http%' OR u.url LIKE 'ftp%'
+                        """
+                    )
+                    for row in cur:
+                        unix_us = _chrome_to_unix_us(row["visit_time"])
+                        if unix_us <= cutoff_unix_us:
+                            continue
+                        url = row["url"]
+                        if not url:
+                            continue
+                        entry = urls_to_data.setdefault(
+                            url,
+                            {
+                                "title": row["title"] or "",
+                                "visit_count": 0,
+                                "last_visit": 0,
+                                "visits": [],
+                            },
+                        )
+                        entry["visit_count"] += 1
+                        entry["last_visit"] = max(entry["last_visit"], unix_us)
+                        if row["title"] and len(row["title"]) > len(entry["title"]):
+                            entry["title"] = row["title"]
+                        entry["visits"].append((unix_us, _map_transition(row["transition"])))
+                finally:
+                    conn.close()
+        finally:
+            self._cleanup()
+
+        logger.info(
+            f"🔍 Aggregated {len(urls_to_data)} URLs from Arc history "
+            f"({sum(d['visit_count'] for d in urls_to_data.values())} visits)"
+        )
+        if not urls_to_data:
+            return result
+
+        if self.dry_run:
+            result["dry_run"] = True
+            result["places_added"] = len(urls_to_data)
+            result["visits_added"] = sum(d["visit_count"] for d in urls_to_data.values())
+            return result
+
+        backup = self.places_db.with_name(f"{self.places_db.name}.backup.{int(time.time())}")
+        shutil.copy2(self.places_db, backup)
+        logger.info(f"💾 Backed up places.sqlite → {backup.name}")
+
+        conn = sqlite3.connect(self.places_db, timeout=30.0)
+        try:
+            cur = conn.cursor()
+            cur.execute("PRAGMA journal_mode=WAL")
+            cur.execute("BEGIN")
+            for url, data in urls_to_data.items():
+                place_id, was_new = self._upsert_place(cur, url, data)
+                if was_new:
+                    result["places_added"] += 1
+                else:
+                    result["places_updated"] += 1
+                visits_added = self._insert_visits(cur, place_id, data["visits"])
+                result["visits_added"] += visits_added
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        logger.info(
+            f"✅ History: +{result['places_added']} new places, "
+            f"~{result['places_updated']} merged, +{result['visits_added']} visits"
+        )
+        return result
+
+    @staticmethod
+    def _upsert_place(cur: sqlite3.Cursor, url: str, data: dict) -> tuple[int, bool]:
+        url_hash = hash_page_url(url)
+        cur.execute(
+            "SELECT id, visit_count, last_visit_date, title FROM moz_places "
+            "WHERE url_hash = ? AND url = ?",
+            (url_hash, url),
+        )
+        row = cur.fetchone()
+        if row:
+            place_id, existing_visits, existing_last, existing_title = row
+            new_visit_count = (existing_visits or 0) + data["visit_count"]
+            new_last = max(existing_last or 0, data["last_visit"])
+            new_title = existing_title if existing_title else data["title"] or None
+            cur.execute(
+                "UPDATE moz_places SET visit_count = ?, last_visit_date = ?, title = ? "
+                "WHERE id = ?",
+                (new_visit_count, new_last, new_title, place_id),
+            )
+            return place_id, False
+
+        rev_host = _reverse_host(url)
+        guid = _make_guid()
+        cur.execute(
+            """INSERT INTO moz_places
+               (url, title, rev_host, visit_count, hidden, typed, frecency,
+                last_visit_date, guid, foreign_count, url_hash)
+               VALUES (?, ?, ?, ?, 0, 0, ?, ?, ?, 0, ?)""",
+            (
+                url,
+                data["title"] or None,
+                rev_host,
+                data["visit_count"],
+                _frecency(data["visit_count"]),
+                data["last_visit"],
+                guid,
+                url_hash,
+            ),
+        )
+        return cur.lastrowid, True
+
+    @staticmethod
+    def _insert_visits(cur: sqlite3.Cursor, place_id: int, visits: list[tuple[int, int]]) -> int:
+        # Skip visits already present (by exact place_id+visit_date).
+        existing = {
+            row[0]
+            for row in cur.execute(
+                "SELECT visit_date FROM moz_historyvisits WHERE place_id = ?",
+                (place_id,),
+            )
+        }
+        added = 0
+        for visit_us, visit_type in visits:
+            if visit_us in existing:
+                continue
+            cur.execute(
+                """INSERT INTO moz_historyvisits
+                   (from_visit, place_id, visit_date, visit_type, session)
+                   VALUES (0, ?, ?, ?, 0)""",
+                (place_id, visit_us, visit_type),
+            )
+            added += 1
+        return added
+
+
+def _frecency(visit_count: int) -> int:
+    """Cheap frecency estimate. Firefox recomputes on its own; this is a starting score."""
+    return min(10000, 100 + visit_count * 50)
+
+
+def _make_guid() -> str:
+    """12-char base64url GUID, matching moz_places.guid format."""
+    import base64
+    import os
+    return base64.urlsafe_b64encode(os.urandom(9)).decode("ascii")
+
+
+def main() -> int:
+    import argparse
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    parser = argparse.ArgumentParser(description="Import Arc browsing history into Zen")
+    parser.add_argument("--zen-profile", help="Zen profile name (partial match)")
+    parser.add_argument("--since-days", type=int, help="Only import visits newer than N days")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    profiles_root = Path.home() / "Library/Application Support/zen/Profiles"
+    if not profiles_root.exists():
+        logger.error(f"No Zen profile dir at {profiles_root}")
+        return 1
+    profiles = [p for p in profiles_root.iterdir() if p.is_dir()]
+    if args.zen_profile:
+        profiles = [p for p in profiles if args.zen_profile.lower() in p.name.lower()]
+    if not profiles:
+        logger.error("No matching Zen profile found")
+        return 1
+    zen_profile = profiles[0]
+    logger.info(f"Using Zen profile: {zen_profile.name}")
+
+    importer = HistoryImporter(zen_profile, dry_run=args.dry_run)
+    summary = importer.import_history(since_days=args.since_days)
+    logger.info(f"Summary: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/zen_favicon_importer.py
+++ b/src/zen_favicon_importer.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""
+Arc → Zen Favicon Importer
+
+Reads favicons from Arc's Chromium-format Favicons SQLite database and
+imports them into Zen's Firefox-format favicons.sqlite, linking each
+favicon to the page URLs that were migrated from Arc spaces.
+
+Hash algorithms mirror Firefox's mozilla::HashString and places::HashURL
+so Zen finds the inserted entries via its hash-indexed lookups.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import shutil
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Firefox MFBT golden ratio prime used by mozilla::AddToHash.
+_GOLDEN_RATIO_U32 = 0x9E3779B9
+
+
+def _add_to_hash(h: int, b: int) -> int:
+    rotated = ((h << 5) | (h >> 27)) & 0xFFFFFFFF
+    return (_GOLDEN_RATIO_U32 * (rotated ^ b)) & 0xFFFFFFFF
+
+
+def _hash_string(s: str) -> int:
+    h = 0
+    for byte in s.encode("utf-8"):
+        h = _add_to_hash(h, byte)
+    return h
+
+
+def hash_page_url(url: str) -> int:
+    """places::HashURL — 48-bit hash with prefix in upper 16 bits."""
+    full = _hash_string(url)
+    idx = url.find(":")
+    prefix = _hash_string(url[:idx]) if idx > 0 else 0
+    return (((prefix & 0xFFFF) << 32) | full) & 0xFFFFFFFFFFFF
+
+
+def fixed_icon_url(icon_url: str) -> str:
+    """Firefox normalizes icon URLs by stripping the scheme and leading 'www.'."""
+    s = icon_url
+    for scheme in ("https://", "http://"):
+        if s.startswith(scheme):
+            s = s[len(scheme):]
+            break
+    if s.startswith("www."):
+        s = s[4:]
+    return s
+
+
+def hash_icon_url(icon_url: str) -> int:
+    return _hash_string(fixed_icon_url(icon_url))
+
+
+# Chromium icon_type values (chrome/browser/favicon/favicon_types.h).
+# 1 = FAVICON (preferred), 2/3 = TOUCH_ICON, 4 = WEB_MANIFEST_ICON.
+_ICON_TYPE_PRIORITY = {1: 4, 2: 3, 3: 2, 4: 1}
+
+
+def _detect_image_mime(blob: bytes) -> str:
+    """Sniff image format from the leading bytes."""
+    if blob.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if blob[:3] == b"GIF":
+        return "image/gif"
+    if blob[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if blob[:4] == b"RIFF" and blob[8:12] == b"WEBP":
+        return "image/webp"
+    if blob[:4] == b"\x00\x00\x01\x00":
+        return "image/x-icon"
+    if blob.lstrip()[:5] in (b"<?xml", b"<svg "):
+        return "image/svg+xml"
+    return "image/png"  # safest default — Firefox decoders accept misnamed PNGs
+
+
+class FaviconImporter:
+    """Imports favicons from Arc's Chromium DB into Zen's favicons.sqlite."""
+
+    DEFAULT_EXPIRE_DAYS = 28
+
+    def __init__(self, zen_profile_path: Path, dry_run: bool = False):
+        self.zen_profile = Path(zen_profile_path)
+        self.zen_favicons_db = self.zen_profile / "favicons.sqlite"
+        self.dry_run = dry_run
+        self._tempdir: Optional[Path] = None
+
+    def find_arc_favicon_dbs(self) -> list[Path]:
+        """Locate every Arc profile's Favicons SQLite file."""
+        candidates: list[Path] = []
+        home = Path.home()
+        macos = home / "Library" / "Application Support" / "Arc" / "User Data"
+        windows = (
+            home
+            / "AppData/Local/Packages/TheBrowserCompany.Arc_ttt1ap7aakyb4"
+            / "LocalCache/Local/Arc/User Data"
+        )
+        for root in (macos, windows):
+            if root.exists():
+                candidates.extend(p for p in root.glob("*/Favicons") if p.is_file())
+        return sorted(set(candidates))
+
+    def _snapshot_db(self, src: Path) -> Path:
+        """Copy a SQLite db to a temp dir so we can read it without lock contention."""
+        if self._tempdir is None:
+            self._tempdir = Path(tempfile.mkdtemp(prefix="arc2zen_favicons_"))
+        dest = self._tempdir / f"{src.parent.name}_{src.name}.db"
+        shutil.copy2(src, dest)
+        for suffix in ("-wal", "-shm", "-journal"):
+            sibling = src.with_name(src.name + suffix)
+            if sibling.exists():
+                shutil.copy2(sibling, dest.with_name(dest.name + suffix))
+        return dest
+
+    def _cleanup_temp(self) -> None:
+        if self._tempdir and self._tempdir.exists():
+            shutil.rmtree(self._tempdir, ignore_errors=True)
+            self._tempdir = None
+
+    @staticmethod
+    def _normalize(url: str) -> str:
+        """Normalize a URL for fuzzy matching (strip fragment, trailing slash)."""
+        if "#" in url:
+            url = url.split("#", 1)[0]
+        if url.endswith("/"):
+            url = url[:-1]
+        return url
+
+    @staticmethod
+    def _origin(url: str) -> Optional[str]:
+        try:
+            p = urlparse(url)
+        except ValueError:
+            return None
+        if not p.scheme or not p.netloc:
+            return None
+        return f"{p.scheme}://{p.netloc}"
+
+    def _collect_arc_favicons(
+        self, page_urls: set[str]
+    ) -> dict[str, tuple[str, bytes, int]]:
+        """For each requested page URL, return best (icon_url, image_data, width)."""
+
+        # Build lookup keys: exact, normalized (no fragment / trailing slash), origin.
+        normalized_to_original: dict[str, str] = {}
+        origin_to_original: dict[str, str] = {}
+        for url in page_urls:
+            normalized_to_original.setdefault(self._normalize(url), url)
+            origin = self._origin(url)
+            if origin:
+                origin_to_original.setdefault(origin, url)
+
+        # (page_url -> (icon_url, image_bytes, width, score)) — score is the tie-breaker.
+        best: dict[str, tuple[str, bytes, int, tuple]] = {}
+
+        for arc_db in self.find_arc_favicon_dbs():
+            logger.info(f"📖 Reading Arc favicons from {arc_db.parent.name}")
+            try:
+                snap = self._snapshot_db(arc_db)
+            except Exception as exc:
+                logger.warning(f"Could not snapshot {arc_db}: {exc}")
+                continue
+
+            conn = sqlite3.connect(f"file:{snap}?mode=ro", uri=True)
+            conn.row_factory = sqlite3.Row
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    SELECT
+                        im.page_url AS page_url,
+                        f.url       AS icon_url,
+                        fb.image_data AS image_data,
+                        fb.width    AS width,
+                        fb.height   AS height,
+                        f.icon_type AS icon_type
+                    FROM icon_mapping im
+                    JOIN favicons f          ON f.id  = im.icon_id
+                    JOIN favicon_bitmaps fb  ON fb.icon_id = f.id
+                    WHERE fb.image_data IS NOT NULL AND length(fb.image_data) > 0
+                    """
+                )
+                for row in cur:
+                    arc_page = row["page_url"]
+                    matched_url = self._match_url(
+                        arc_page, page_urls, normalized_to_original, origin_to_original
+                    )
+                    if matched_url is None:
+                        continue
+                    score = self._score(row, exact=arc_page in page_urls)
+                    existing = best.get(matched_url)
+                    if existing is None or score > existing[3]:
+                        best[matched_url] = (
+                            row["icon_url"],
+                            bytes(row["image_data"]),
+                            int(row["width"] or 0),
+                            score,
+                        )
+            finally:
+                conn.close()
+
+        return {url: (icon_url, data, width) for url, (icon_url, data, width, _) in best.items()}
+
+    def _match_url(
+        self,
+        arc_page: str,
+        page_urls: set[str],
+        normalized_to_original: dict[str, str],
+        origin_to_original: dict[str, str],
+    ) -> Optional[str]:
+        if arc_page in page_urls:
+            return arc_page
+        norm = self._normalize(arc_page)
+        if norm in normalized_to_original:
+            return normalized_to_original[norm]
+        origin = self._origin(arc_page)
+        if origin and origin in origin_to_original:
+            return origin_to_original[origin]
+        return None
+
+    @staticmethod
+    def _score(row: sqlite3.Row, exact: bool) -> tuple:
+        """Higher tuple wins. Prefer exact URL, then larger size, then favicon type."""
+        size = max(int(row["width"] or 0), int(row["height"] or 0))
+        type_pri = _ICON_TYPE_PRIORITY.get(row["icon_type"], 0)
+        return (
+            1 if exact else 0,
+            size,
+            type_pri,
+            len(row["image_data"] or b""),
+        )
+
+    def inject_session_images(self, page_urls: Iterable[str]) -> dict:
+        """Embed favicon data URIs in each tab's `image` field in zen-sessions.jsonlz4.
+
+        Pinned tab favicons in modern Zen are rendered from the tab's inline `image`
+        field (a `data:image/...;base64,...` URI), not from favicons.sqlite. This
+        looks up Arc favicons for each tab URL and writes them inline so icons
+        appear immediately when Zen starts.
+        """
+        from zen_sessions_importer import read_mozlz4, write_mozlz4
+
+        urls = {u for u in page_urls if u}
+        result = {"requested": len(urls), "matched": 0, "updated": 0, "skipped": 0}
+        sessions_file = self.zen_profile / "zen-sessions.jsonlz4"
+        if not sessions_file.exists():
+            logger.warning(f"zen-sessions.jsonlz4 not found at {sessions_file} — skipping inline injection")
+            result["error"] = "sessions_missing"
+            return result
+
+        try:
+            arc_favicons = self._collect_arc_favicons(urls)
+        finally:
+            self._cleanup_temp()
+        result["matched"] = len(arc_favicons)
+        logger.info(f"🔍 Matched favicons for {len(arc_favicons)} of {len(urls)} URLs")
+
+        if not arc_favicons:
+            return result
+
+        # Encode each match as a data URI once.
+        url_to_data_uri: dict[str, str] = {}
+        for page_url, (_icon_url, image_data, _width) in arc_favicons.items():
+            if not image_data:
+                continue
+            mime = _detect_image_mime(image_data)
+            b64 = base64.b64encode(image_data).decode("ascii")
+            url_to_data_uri[page_url] = f"data:{mime};base64,{b64}"
+
+        if self.dry_run:
+            logger.info(f"🧪 DRY RUN: would inline {len(url_to_data_uri)} favicons into zen-sessions.jsonlz4")
+            result["dry_run"] = True
+            return result
+
+        # Read, mutate, write — with a backup first.
+        backup = sessions_file.with_name(f"{sessions_file.name}.backup.{int(time.time())}")
+        shutil.copy2(sessions_file, backup)
+        logger.info(f"💾 Backed up zen-sessions.jsonlz4 → {backup.name}")
+
+        session = read_mozlz4(sessions_file)
+        for tab in session.get("tabs", []):
+            if tab.get("image"):
+                continue  # already has an icon (likely native Zen pinned tab)
+            url = self._extract_tab_url(tab)
+            if not url:
+                result["skipped"] += 1
+                continue
+            data_uri = url_to_data_uri.get(url)
+            if not data_uri:
+                # Fall back to normalized / origin lookup.
+                normalized_to_uri = {self._normalize(u): du for u, du in url_to_data_uri.items()}
+                origin_to_uri = {}
+                for u, du in url_to_data_uri.items():
+                    o = self._origin(u)
+                    if o:
+                        origin_to_uri.setdefault(o, du)
+                data_uri = normalized_to_uri.get(self._normalize(url))
+                if not data_uri:
+                    origin = self._origin(url)
+                    data_uri = origin_to_uri.get(origin) if origin else None
+            if not data_uri:
+                result["skipped"] += 1
+                continue
+            tab["image"] = data_uri
+            result["updated"] += 1
+
+        write_mozlz4(sessions_file, session)
+        logger.info(f"✅ Injected favicons into {result['updated']} tabs (skipped {result['skipped']})")
+        return result
+
+    @staticmethod
+    def _extract_tab_url(tab: dict) -> Optional[str]:
+        """Pull the active URL out of a session tab entry."""
+        entries = tab.get("entries") or []
+        if entries:
+            idx = tab.get("index", len(entries)) - 1
+            if 0 <= idx < len(entries):
+                url = entries[idx].get("url")
+                if url:
+                    return url
+            url = entries[-1].get("url")
+            if url:
+                return url
+        return tab.get("userTypedValue") or None
+
+    def import_favicons(self, page_urls: Iterable[str]) -> dict:
+        urls = {u for u in page_urls if u}
+        result = {"requested": len(urls), "matched": 0, "imported": 0, "skipped": 0}
+        if not urls:
+            return result
+        if not self.zen_favicons_db.exists():
+            logger.error(f"Zen favicons.sqlite not found at {self.zen_favicons_db}")
+            result["error"] = "favicons_db_missing"
+            return result
+
+        try:
+            arc_favicons = self._collect_arc_favicons(urls)
+        finally:
+            self._cleanup_temp()
+
+        result["matched"] = len(arc_favicons)
+        logger.info(
+            f"🔍 Matched favicons for {len(arc_favicons)} of {len(urls)} requested URLs"
+        )
+
+        if not arc_favicons:
+            return result
+
+        if self.dry_run:
+            logger.info(f"🧪 DRY RUN: would import {len(arc_favicons)} favicons")
+            result["dry_run"] = True
+            return result
+
+        backup = self.zen_favicons_db.with_name(
+            f"{self.zen_favicons_db.name}.backup.{int(time.time())}"
+        )
+        shutil.copy2(self.zen_favicons_db, backup)
+        logger.info(f"💾 Backed up favicons.sqlite → {backup.name}")
+
+        now_ms = int(time.time() * 1000)
+        expire_ms = now_ms + self.DEFAULT_EXPIRE_DAYS * 24 * 60 * 60 * 1000
+
+        conn = sqlite3.connect(self.zen_favicons_db, timeout=10.0)
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN")
+            for page_url, (icon_url, image_data, width) in arc_favicons.items():
+                if not image_data:
+                    result["skipped"] += 1
+                    continue
+                icon_id = self._upsert_icon(cur, icon_url, image_data, width, expire_ms)
+                page_id = self._upsert_page(cur, page_url)
+                cur.execute(
+                    """INSERT OR REPLACE INTO moz_icons_to_pages
+                          (page_id, icon_id, expire_ms) VALUES (?, ?, ?)""",
+                    (page_id, icon_id, expire_ms),
+                )
+                result["imported"] += 1
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        logger.info(
+            f"✅ Imported {result['imported']} favicons "
+            f"(skipped {result['skipped']})"
+        )
+        return result
+
+    @staticmethod
+    def _upsert_icon(
+        cur: sqlite3.Cursor,
+        icon_url: str,
+        image_data: bytes,
+        width: int,
+        expire_ms: int,
+    ) -> int:
+        url_hash = hash_icon_url(icon_url)
+        cur.execute(
+            "SELECT id FROM moz_icons WHERE fixed_icon_url_hash=? AND icon_url=?",
+            (url_hash, icon_url),
+        )
+        row = cur.fetchone()
+        if row:
+            cur.execute(
+                "UPDATE moz_icons SET data=?, width=?, expire_ms=? WHERE id=?",
+                (sqlite3.Binary(image_data), width or 16, expire_ms, row[0]),
+            )
+            return row[0]
+        cur.execute(
+            """INSERT INTO moz_icons
+                  (icon_url, fixed_icon_url_hash, width, root, color,
+                   expire_ms, flags, data)
+                  VALUES (?, ?, ?, 0, NULL, ?, 0, ?)""",
+            (icon_url, url_hash, width or 16, expire_ms, sqlite3.Binary(image_data)),
+        )
+        return cur.lastrowid
+
+    @staticmethod
+    def _upsert_page(cur: sqlite3.Cursor, page_url: str) -> int:
+        url_hash = hash_page_url(page_url)
+        cur.execute(
+            "SELECT id FROM moz_pages_w_icons WHERE page_url_hash=? AND page_url=?",
+            (url_hash, page_url),
+        )
+        row = cur.fetchone()
+        if row:
+            return row[0]
+        cur.execute(
+            "INSERT INTO moz_pages_w_icons (page_url, page_url_hash) VALUES (?, ?)",
+            (page_url, url_hash),
+        )
+        return cur.lastrowid
+
+
+def _iter_pinned_urls(extracted: dict) -> Iterable[str]:
+    """Walk the structure produced by ArcPinnedTabExtractor.export_data()."""
+    for space in extracted.get("spaces", []):
+        for tab in space.get("pinned_tabs", []) or []:
+            url = tab.get("url")
+            if url:
+                yield url
+        for tab in space.get("essential_tabs", []) or []:
+            url = tab.get("url")
+            if url:
+                yield url
+        for tab in space.get("open_tabs", []) or []:
+            url = tab.get("url")
+            if url:
+                yield url
+        for folder in space.get("folders", []) or []:
+            for tab in folder.get("tabs", []) or []:
+                url = tab.get("url")
+                if url:
+                    yield url
+
+
+def main() -> int:
+    """CLI: import Arc favicons for all pinned URLs in arc_pinned_tabs_export.json."""
+    import argparse
+    import json
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    parser = argparse.ArgumentParser(description="Import Arc favicons into Zen")
+    parser.add_argument("--zen-profile", help="Zen profile name (partial match)")
+    parser.add_argument("--export-file", default="arc_pinned_tabs_export.json")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    home = Path.home()
+    profiles_root = home / "Library/Application Support/zen/Profiles"
+    if not profiles_root.exists():
+        logger.error(f"No Zen profile dir at {profiles_root}")
+        return 1
+    profiles = [p for p in profiles_root.iterdir() if p.is_dir()]
+    if args.zen_profile:
+        profiles = [p for p in profiles if args.zen_profile.lower() in p.name.lower()]
+    if not profiles:
+        logger.error("No matching Zen profile found")
+        return 1
+    zen_profile = profiles[0]
+    logger.info(f"Using Zen profile: {zen_profile.name}")
+
+    export_path = Path(args.export_file)
+    if export_path.exists():
+        with export_path.open() as fh:
+            data = json.load(fh)
+        urls = list(dict.fromkeys(_iter_pinned_urls(data)))
+        logger.info(f"Found {len(urls)} unique URLs in {export_path.name}")
+    else:
+        logger.info(f"No {export_path.name} found — extracting URLs from Arc")
+        from arc_pinned_tab_extractor import ArcPinnedTabExtractor
+        extractor = ArcPinnedTabExtractor()
+        spaces = extractor.extract_pinned_tabs()
+        if not spaces:
+            logger.error("No Arc data found. Is Arc installed?")
+            return 1
+        # Reuse the extractor's JSON exporter to get a stable dict shape.
+        tmp = export_path.parent / f".arc2zen_favicon_tmp_{int(time.time())}.json"
+        try:
+            extractor.export_to_json(spaces, tmp)
+            with tmp.open() as fh:
+                export_data = json.load(fh)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
+        urls = list(dict.fromkeys(_iter_pinned_urls(export_data)))
+        logger.info(f"Extracted {len(urls)} unique URLs from Arc")
+
+    importer = FaviconImporter(zen_profile, dry_run=args.dry_run)
+    db_summary = importer.import_favicons(urls)
+    logger.info(f"favicons.sqlite: {db_summary}")
+    session_summary = importer.inject_session_images(urls)
+    logger.info(f"zen-sessions.jsonlz4: {session_summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/zen_favicon_importer.py
+++ b/src/zen_favicon_importer.py
@@ -41,7 +41,7 @@ def _hash_string(s: str) -> int:
 
 
 def hash_page_url(url: str) -> int:
-    """places::HashURL — 48-bit hash with prefix in upper 16 bits."""
+    """places::HashURL. 48-bit hash with prefix in upper 16 bits."""
     full = _hash_string(url)
     idx = url.find(":")
     prefix = _hash_string(url[:idx]) if idx > 0 else 0
@@ -83,7 +83,7 @@ def _detect_image_mime(blob: bytes) -> str:
         return "image/x-icon"
     if blob.lstrip()[:5] in (b"<?xml", b"<svg "):
         return "image/svg+xml"
-    return "image/png"  # safest default — Firefox decoders accept misnamed PNGs
+    return "image/png"  # safest default. Firefox decoders accept misnamed PNGs
 
 
 class FaviconImporter:
@@ -162,7 +162,7 @@ class FaviconImporter:
             if origin:
                 origin_to_original.setdefault(origin, url)
 
-        # (page_url -> (icon_url, image_bytes, width, score)) — score is the tie-breaker.
+        # page_url -> (icon_url, image_bytes, width, score). score is the tie-breaker.
         best: dict[str, tuple[str, bytes, int, tuple]] = {}
 
         for arc_db in self.find_arc_favicon_dbs():
@@ -256,7 +256,7 @@ class FaviconImporter:
         result = {"requested": len(urls), "matched": 0, "updated": 0, "skipped": 0}
         sessions_file = self.zen_profile / "zen-sessions.jsonlz4"
         if not sessions_file.exists():
-            logger.warning(f"zen-sessions.jsonlz4 not found at {sessions_file} — skipping inline injection")
+            logger.warning(f"zen-sessions.jsonlz4 not found at {sessions_file}. skipping inline injection")
             result["error"] = "sessions_missing"
             return result
 
@@ -284,7 +284,7 @@ class FaviconImporter:
             result["dry_run"] = True
             return result
 
-        # Read, mutate, write — with a backup first.
+        # Read, mutate, write (with a backup first).
         backup = sessions_file.with_name(f"{sessions_file.name}.backup.{int(time.time())}")
         shutil.copy2(sessions_file, backup)
         logger.info(f"💾 Backed up zen-sessions.jsonlz4 → {backup.name}")
@@ -505,7 +505,7 @@ def main() -> int:
         urls = list(dict.fromkeys(_iter_pinned_urls(data)))
         logger.info(f"Found {len(urls)} unique URLs in {export_path.name}")
     else:
-        logger.info(f"No {export_path.name} found — extracting URLs from Arc")
+        logger.info(f"No {export_path.name} found: extracting URLs from Arc")
         from arc_pinned_tab_extractor import ArcPinnedTabExtractor
         extractor = ArcPinnedTabExtractor()
         spaces = extractor.extract_pinned_tabs()

--- a/src/zen_sessions_importer.py
+++ b/src/zen_sessions_importer.py
@@ -262,7 +262,7 @@ class ZenSessionsImporter:
             )
             zen_tabs.append(zen_tab)
 
-        # Create about:blank placeholder tab per folder — Zen requires this for validation
+        # Create about:blank placeholder tab per folder - Zen requires this for validation
         timestamp_ms = int(time.time() * 1000)
         for folder in zen_folders:
             placeholder_sync_id = self._generate_sync_id()
@@ -316,7 +316,7 @@ class ZenSessionsImporter:
         merged["splitViewData"] = existing.get("splitViewData", [])
         merged["lastCollected"] = int(time.time() * 1000)
 
-        # Build groups array from ALL folders — Zen injects sidebar.groups into
+        # Build groups array from ALL folders - Zen injects sidebar.groups into
         # the sessionstore initialState so Firefox creates tab-group DOM elements.
         # Without matching groups, gZenFolders.restoreDataFromSessionStore() can't
         # find the DOM elements by ID and silently skips all folders.
@@ -342,7 +342,7 @@ class ZenSessionsImporter:
     def _sync_sessionstore(self, merged: dict) -> None:
         """Sync zen-sessions data into sessionstore as a supplementary safety net.
 
-        zen-sessions.jsonlz4 is the authoritative source — on startup, Zen's
+        zen-sessions.jsonlz4 is the authoritative source - on startup, Zen's
         #restoreWindowData() injects its groups/tabs/folders/spaces into Firefox's
         initialState, overwriting whatever was in the sessionstore. This sync
         is belt-and-suspenders: it pre-populates the sessionstore so that even

--- a/src/zen_sessions_importer.py
+++ b/src/zen_sessions_importer.py
@@ -57,9 +57,10 @@ def write_mozlz4(file_path: Path, data: dict) -> None:
 class ZenSessionsImporter:
     """Imports Arc spaces, pinned tabs, and folders into zen-sessions.jsonlz4."""
 
-    def __init__(self, zen_profile_path: Path):
+    def __init__(self, zen_profile_path: Path, folders_collapsed: bool = True):
         self.zen_profile = zen_profile_path
         self.sessions_file = zen_profile_path / "zen-sessions.jsonlz4"
+        self.folders_collapsed = folders_collapsed
         self._id_counter = 0
 
     # --- ID generation ---
@@ -108,7 +109,7 @@ class ZenSessionsImporter:
     # --- Build structures ---
 
     def _build_space(self, space_data: dict) -> dict:
-        return {
+        space = {
             "uuid": self._generate_space_uuid(),
             "name": space_data["space_name"],
             "theme": {
@@ -120,6 +121,24 @@ class ZenSessionsImporter:
             "containerTabId": 0,
             "hasCollapsedPinnedTabs": False,
         }
+
+        icon = space_data.get("icon")
+        if icon:
+            space["icon"] = icon
+
+        color = space_data.get("color")
+        if color and all(k in color for k in ("r", "g", "b")):
+            r = int(round(color["r"] * 255))
+            g = int(round(color["g"] * 255))
+            b = int(round(color["b"] * 255))
+            space["theme"]["gradientColors"] = [{
+                "c": [r, g, b],
+                "isCustom": False,
+                "algorithm": "floating",
+                "isPrimary": True,
+            }]
+
+        return space
 
     def _build_tab(self, tab_data: dict, workspace_uuid: str,
                    index: int, folder_id: Optional[str] = None) -> dict:
@@ -164,7 +183,7 @@ class ZenSessionsImporter:
             "splitViewGroup": False,
             "id": self._generate_sync_id(),
             "name": folder_data.get("title", "Untitled"),
-            "collapsed": False,
+            "collapsed": self.folders_collapsed,
             "saveOnWindowClose": True,
             "parentId": parent_folder_id,
             "prevSiblingInfo": None,

--- a/src/zen_sessions_importer.py
+++ b/src/zen_sessions_importer.py
@@ -176,6 +176,40 @@ class ZenSessionsImporter:
 
         return tab
 
+    def _build_open_tab(self, tab_data: dict, workspace_uuid: str,
+                         user_context_id: int, index: int) -> dict:
+        """Build a non-pinned open-tab entry that lives in zen-sessions.jsonlz4.
+
+        Open tabs in modern Zen are restored from this file, NOT from
+        sessionstore.jsonlz4 (Zen's #restoreWindowData() overwrites
+        sessionstore on every launch). The schema mirrors a native Zen
+        open tab: ``entries`` carrying the URL/title, ``zenWorkspace``
+        binding the tab to the right workspace, and ``userContextId``
+        scoping cookies to the per-space container.
+        """
+        url = tab_data.get("url", "")
+        title = tab_data.get("title", "")
+        timestamp_ms = int(time.time() * 1000)
+
+        return {
+            "entries": [{"url": url, "title": title}],
+            "lastAccessed": timestamp_ms,
+            "pinned": False,
+            "hidden": False,
+            "zenWorkspace": workspace_uuid,
+            "zenSyncId": self._generate_sync_id(),
+            "zenEssential": False,
+            "zenDefaultUserContextId": None,
+            "zenIsEmpty": False,
+            "zenHasStaticIcon": False,
+            "zenGlanceId": None,
+            "zenIsGlance": False,
+            "searchMode": None,
+            "userContextId": user_context_id,
+            "attributes": {},
+            "index": index,
+        }
+
     def _build_folder(self, folder_data: dict, workspace_uuid: str,
                       parent_folder_id: Optional[str] = None) -> dict:
         return {
@@ -194,10 +228,15 @@ class ZenSessionsImporter:
 
     # --- Core import logic ---
 
-    def _process_space(self, space_data: dict) -> Tuple[dict, List[dict], List[dict]]:
-        """Process a single Arc space into Zen space, folders, and tabs.
+    def _process_space(self, space_data: dict,
+                       user_context_id: int = 0) -> Tuple[dict, List[dict], List[dict]]:
+        """Process a single Arc space into Zen space, folders, and tabs
+        (pinned + open).
 
-        Returns (space_dict, folders_list, tabs_list).
+        ``user_context_id`` scopes the open tabs' cookies to the per-space
+        container; pinned tabs are bound through the workspace's
+        ``containerTabId`` instead. Returns (space_dict, folders_list,
+        tabs_list).
         """
         space = self._build_space(space_data)
         workspace_uuid = space["uuid"]
@@ -261,6 +300,21 @@ class ZenSessionsImporter:
                 index=i + 1, folder_id=folder_id,
             )
             zen_tabs.append(zen_tab)
+
+        # Open (non-pinned) tabs from Arc become open tabs in the Zen
+        # workspace. They live in the same ``tabs`` array as pinned tabs;
+        # Zen distinguishes them via the ``pinned`` flag.
+        open_tabs = space_data.get("open_tabs", []) or []
+        base_index = len(zen_tabs)
+        for j, tab_data in enumerate(open_tabs):
+            url = tab_data.get("url", "")
+            if not url:
+                continue
+            zen_tabs.append(self._build_open_tab(
+                tab_data, workspace_uuid,
+                user_context_id=user_context_id,
+                index=base_index + j + 1,
+            ))
 
         # Create about:blank placeholder tab per folder - Zen requires this for validation
         timestamp_ms = int(time.time() * 1000)
@@ -426,15 +480,21 @@ class ZenSessionsImporter:
 
             for space_data in arc_export_data.get("spaces", []):
                 space_name = space_data["space_name"]
+                container_id = int(container_mappings.get(space_name, 0) or 0)
 
-                space, folders, tabs = self._process_space(space_data)
+                space, folders, tabs = self._process_space(
+                    space_data, user_context_id=container_id,
+                )
                 all_new_spaces.append(space)
                 all_new_folders.extend(folders)
                 all_new_tabs.extend(tabs)
 
+                pinned_n = sum(1 for t in tabs if t.get("pinned"))
+                open_n = sum(1 for t in tabs if not t.get("pinned"))
                 logger.info(
-                    f"  {space_name}: {len(tabs)} pinned tabs, "
-                    f"{len(folders)} folders -> workspace {space['uuid']}"
+                    f"  {space_name}: {pinned_n} pinned tabs, "
+                    f"{open_n} open tabs, {len(folders)} folders "
+                    f"-> workspace {space['uuid']}"
                 )
 
             if dry_run:


### PR DESCRIPTION
This adds the importer features from #21 (which it superseded), the macOS GUI app, **Windows support across the whole stack**, and a single GitHub Actions workflow that ships both platforms.

## What this adds

### Importer features

1. **Favicons** (`src/zen_favicon_importer.py`). Arc's cached icons flow into Zen so tabs aren't blank after migration. The non-trivial part was that **modern Zen renders pinned-tab favicons from each tab's inline `image` data URI in `zen-sessions.jsonlz4`**, not from `favicons.sqlite`, so writing only the SQLite store leaves the sidebar blank. The importer does both. Implements Firefox's `places::HashURL` (mfbt `AddToHash` with the golden-ratio prime, prefix hash in upper 16 bits) so Firefox's hash-indexed lookups actually find the rows.
2. **Folders collapsed by default**. `_build_folder` previously hard-coded `collapsed: false`. Now collapsed; pass `--folders-open` for the previous behaviour.
3. **Space icons and themes actually applied**. `_build_space` was silently dropping the `icon` and `color` fields it received from `arc_pinned_tab_extractor`. Now the Arc emoji and Arc midTone color are written into the Zen workspace.
4. **History import** (`src/arc_history_importer.py`). Copies Arc's `History` SQLite into Zen's `places.sqlite`. Converts WebKit-epoch microseconds (1601-based) to unix microseconds and maps Chromium `PageTransition` codes to Firefox `visit_type`. Idempotent.
5. **Cookies import** (`src/arc_cookies_importer.py`). Cross-platform via internal dispatch:
   - **macOS:** Keychain "Arc Safe Storage" → PBKDF2-HMAC-SHA1 → AES-128 key → AES-128-CBC with all-spaces IV.
   - **Windows:** Local State `os_crypt.encrypted_key` → strip 5-byte `DPAPI` prefix → `crypt32!CryptUnprotectData` via ctypes (no `pywin32` dependency) → AES-256 key → AES-256-GCM (12-byte nonce + ciphertext + 16-byte tag) via the existing `cryptography` library.
   
   Two non-obvious Firefox quirks the implementation matches: `moz_cookies.expiry` is in **milliseconds** in modern Firefox/Zen (legacy was seconds, switched ~v108), and pinned tabs migrated from Arc live inside per-space contextual identity containers (cookie-isolated), so each cookie is also written under `^userContextId=N` for every container in `containers.json`. Structured error codes (`dpapi_wrong_user`, `arc_local_state_missing`, `arc_appbound_encryption`, etc.) surface as friendly per-step messages in the GUI.

### GUI app

A polished single-window app (`app/`) that wraps the importer classes without modifying them. PyWebView shell with a vanilla HTML/CSS/JS frontend (no build step). Six screens (welcome, detect, preview, progress, done, error) plus a backups manager. Live progress with per-step detail derived from log messages.

- `app/orchestrator.py` runs the importer pipeline in order and emits structured `ProgressEvent` dicts.
- `app/progress_bus.py` is a `logging.Handler` subclass that pushes records onto a queue the JS frontend polls every 120 ms.
- `app/env_check.py` does cross-platform Arc/Zen detection (UWP and standalone Arc on Windows; release-vs-default Zen profiles on both), running-process checks via `tasklist` on Windows and `pgrep` on macOS, and dependency presence checks.
- `app/browser_control.py` quits Arc/Zen gracefully (AppleScript on macOS, `taskkill` on Windows) and launches Zen via `open -a` or `Popen([zen.exe])`. Reveal-in-shell uses `open -R` or `explorer /select,`.
- `app/bridge.py` is the JS bridge with `platform()`, env, preview, migration, backups management, `open_url` (stdlib `webbrowser`), `copy_to_clipboard` (`pbcopy` on macOS, `clip.exe` on Windows), and a deferred `quit_app` that schedules `window.destroy()` on a 50 ms timer so JS-Python promises can settle before tear-down.
- `app/window.py` is frameless + vibrancy + easy_drag on macOS for the custom Linear/Raycast-style titlebar; on Windows it leaves the OS-native chrome alone (snap zones, Aero shake, multi-monitor DPI handling work for free).
- `app/__main__.py` sets the Windows AppUserModelID via ctypes so the taskbar groups Arc2Zen as its own app instead of under "Python".
- `app/frontend/` is vanilla HTML/CSS/JS, no build step. `body[data-platform]` gates the fake titlebar to macOS. Brand marks for Arc and Zen rendered inline. Font stack puts `Segoe UI` ahead of `system-ui` so older WebView2 builds on Windows 10 don't fall back to Microsoft Sans Serif.

### Build and release pipeline

Both platforms reproducible from source, no external installers, no code-signing certificates required.

**macOS** (`build/make_iconset.sh`, `build/make_app.sh`, `build/make_dmg.sh`):
- `qlmanage` + `sips` + `iconutil` for the `.icns`, `pyinstaller` for the `.app`, `codesign --force --deep --sign -` for ad-hoc signing, `hdiutil` for the `.dmg`.

**Windows** (`build/make_iconset.ps1`, `build/make_exe.ps1`, `build/make_zip.ps1`):
- ImageMagick for the multi-resolution `.ico`, `pyinstaller --onedir` for the `.exe`, `Compress-Archive` for the `.zip`. PowerShell scripts; no node, no npm, no brew dependencies.

`build/arc2zen.spec` is a single PyInstaller spec with platform-aware hidden imports (pyobjc on macOS; `pythonnet`, `clr_loader`, `webview.platforms.edgechromium` on Windows) so a missing import on either platform is one place to fix.

`build/INSTRUCTIONS.txt` documents both platforms' first-launch flows.

### CI

`.github/workflows/release.yml` was a single `macos-14` job; now it's three:

```
resolve-version (ubuntu-latest) ─→ build-macos (macos-14)    ─┐
                                  build-windows (windows-latest) ┤→ release (ubuntu-latest)
                                                                ─┘
```

Both build jobs smoke-test their artifact (launch the app, wait 5s, verify alive, AppleScript-quit on macOS, `Stop-Process` on Windows). The release job downloads both artifacts and creates the GitHub Release with the `.dmg`, `.zip`, and `INSTRUCTIONS.txt` all attached. Body includes the macOS Sequoia and Windows SmartScreen first-launch flows inline.

### Documentation

- README rewritten user-first. Install split into per-platform sections (macOS Sequoia 7-step flow + Windows Unblock-then-Run-anyway flow). Architecture notes for contributors below.
- `CLAUDE.md` documents the new importer modules and the `app/` architecture.

## Verified

- macOS arm64 (`v1.0.0` shipped, `v1.1.0` re-built): full migration end-to-end on a real machine with ~450 pinned tabs across 6 spaces, ~8k cookies, ~220k URL / 540k visit history.
- CI release pipeline tested via `v1.1.0-rc1` tag: both `build-macos` and `build-windows` green in 2m20s, both artifacts published to the [v1.1.0-rc1 release](https://github.com/tarikbc/arc2zen/releases/tag/v1.1.0-rc1) automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)